### PR TITLE
[WIP, don't merge] Option refurbish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ _build
 .nyc*
 .merlin
 node_modules
-

--- a/.screenrc
+++ b/.screenrc
@@ -1,0 +1,5 @@
+sessionname "bs-containers test console"
+screen -t "bsb -- `C-a \` to quit" 0 npm run watch:bsb
+split
+focus down
+screen -t "ava -- `C-a \` to quit - `C-a Esc` to scroll" 1 npm run watch:ava

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -5,6 +5,7 @@
         "dir": "src"
     }, {
         "dir": "test",
+        "subdirs": ["__tests__"],
         "type": "dev"
     }]
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "This is a Bucklescript port of the ocaml-containers project",
   "main": "index.js",
   "scripts": {
+    "start": "bsb -w",
     "build": "bsb",
     "clean": "rm -rf lib",
     "coverage": "nyc report --reporter=html",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "clean": "rm -rf lib",
     "coverage": "npm run build && nyc ava && nyc report --reporter=html",
     "doc": "ocamldoc -html -I lib/bs/src -d doc src/*.mli",
-    "test": "npm run build && ava"
+    "test": "npm run build && ava",
+    "watch:bsb": "bsb -make-world -w",
+    "watch:ava": "ava -w",
+    "watch:screen": "screen -c .screenrc"    
   },
   "keywords": [],
   "author": "Bob Fang",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,9 @@
     "start": "bsb -w",
     "build": "bsb",
     "clean": "rm -rf lib",
-    "coverage": "nyc report --reporter=html",
+    "coverage": "npm run build && nyc ava && nyc report --reporter=html",
     "doc": "ocamldoc -html -I lib/bs/src -d doc src/*.mli",
-    "start": "bsb -w",
-    "test": "nyc ava lib/js/test/*test.js lib/js/test/*Test.js"
+    "test": "npm run build && ava"
   },
   "keywords": [],
   "author": "Bob Fang",
@@ -30,5 +29,14 @@
   "bugs": {
     "url": "https://github.com/dorafmon/bscontainers/issues"
   },
-  "homepage": "https://github.com/dorafmon/bscontainers#readme"
+  "homepage": "https://github.com/dorafmon/bscontainers#readme",
+
+  "ava": {
+    "files": [
+      "**/*_test.js",
+      "!**/amdjs/**",
+      "!**/es6/**",
+      "!**/commonjs/**"
+    ]
+  }
 }

--- a/src/bopt.ml
+++ b/src/bopt.ml
@@ -112,7 +112,7 @@ let reduce f acc o = match o with
 
 let filter p o = match o with
   | Some x when p x -> o
-  | o -> o
+  | _ -> o
 
 
 let apply f x = match f, x with

--- a/src/bopt.ml
+++ b/src/bopt.ml
@@ -1,123 +1,34 @@
 
 (* This file is free software, part of containers. See file "license" for more details. *)
 
+(*
+TODO:
+
+- [x] Use `camelCase` instead of `snake_case`
+- [x] Get rid of scary monadic and math-y terminology
+- [x] Follow the conventions used in the `Js.*` modules
+- [ ] Type functions correctly, e.g. `compare` should return a proper variant, not `0`, `1` or `-1`
+- [x] Remove operators and aliases, e.g. `pure` as an alias for `return`
+- [x] Remove the use of exceptions for internal logic (maybe? seems very sketchy to me but perhaps there's a really really good reason, see [this example](https://github.com/BuckleTypes/bs-containers/blob/master/src/bopt.ml#L163))
+- [x] Replace `Format.printf` calls, they pull in a lot stuff for little benefit
+- [ ] Document everything properly, with examples
+- [ ] Add tests for everything
+*)
+
 (** {1 Options} *)
 
 type 'a t = 'a option
 
-let map f = function
-  | None -> None
-  | Some x -> Some (f x)
+let make x = Some x
 
-let map_or ~default f = function
-  | None -> default
-  | Some x -> f x
+let fromList = function
+  | x::_ -> Some x
+  | [] -> None
 
-let maybe f default = map_or ~default f
-
-let is_some = function
-  | None -> false
-  | Some _ -> true
-
-let is_none = function
-  | None -> true
-  | Some _ -> false
-
-let compare f o1 o2 = match o1, o2 with
-  | None, None -> 0
-  | Some _, None -> 1
-  | None, Some _ -> -1
-  | Some x, Some y -> f x y
-
-let equal f o1 o2 = match o1, o2 with
-  | None, None -> true
-  | Some _, None
-  | None, Some _ -> false
-  | Some x, Some y -> f x y
-
-let return x = Some x
-
-let (>|=) x f = map f x
-
-let (>>=) o f = match o with
-  | None -> None
-  | Some x -> f x
-
-let flat_map f o = match o with
-  | None -> None
-  | Some x -> f x
-
-let pure x = Some x
-
-let (<*>) f x = match f, x with
-  | None, _
-  | _, None -> None
-  | Some f, Some x -> Some (f x)
-
-let (<$>) = map
-
-let (<+>) a b = match a with
-  | None -> b
-  | Some _ -> a
-
-let choice l = List.fold_left (<+>) None l
-
-let map2 f o1 o2 = match o1, o2 with
-  | None, _
-  | _, None -> None
-  | Some x, Some y -> Some (f x y)
-
-let filter p = function
-  | Some x as o when p x -> o
-  | o -> o
-
-let if_ p x = if p x then Some x else None
-
-let exists p = function
-  | None -> false
-  | Some x -> p x
-
-let for_all p = function
-  | None -> true
-  | Some x -> p x
-
-let iter f o = match o with
-  | None -> ()
-  | Some x -> f x
-
-let fold f acc o = match o with
-  | None -> acc
-  | Some x -> f acc x
-
-let get default x = match x with
-  | None -> default
-  | Some y -> y
-
-let get_or ~default x = match x with
-  | None -> default
-  | Some y -> y
-
-let get_exn = function
-  | Some x -> x
-  | None -> invalid_arg "CCOpt.get_exn"
-
-let get_lazy default_fn x = match x with
-  | None -> default_fn ()
-  | Some y -> y
-
-let sequence_l l =
-  let rec aux acc l = match l with
-    | [] -> Some (List.rev acc)
-    | Some x :: l' -> aux (x::acc) l'
-    | None :: _ -> raise Exit
-  in
-  try aux [] l with Exit -> None
-
-(*$T
-  sequence_l [None; Some 1; Some 2] = None
-  sequence_l [Some 1; Some 2; Some 3] = Some [1;2;3]
-  sequence_l [] = Some []
-*)
+let if_ p x =
+  if p x
+  then Some x
+  else None
 
 let wrap ?(handler=fun _ -> true) f x =
   try Some (f x)
@@ -129,60 +40,119 @@ let wrap2 ?(handler=fun _ -> true) f x y =
   with e ->
     if handler e then None else raise e
 
-let to_list o = match o with
+
+let isSome = function
+  | None -> false
+  | Some _ -> true
+
+let isNone = function
+  | None -> true
+  | Some _ -> false
+
+let equal f o1 o2 = match o1, o2 with
+  | None, None -> true
+  | Some _, None
+  | None, Some _ -> false
+  | Some x, Some y -> f x y
+
+let compare f o1 o2 = match o1, o2 with
+  | None, None -> 0
+  | Some _, None -> 1
+  | None, Some _ -> -1
+  | Some x, Some y -> f x y
+
+
+let get default x = match x with
+  | None -> default
+  | Some y -> y
+
+let getOr ~default x = match x with
+  | None -> default
+  | Some y -> y
+
+let getOrRaise = function
+  | Some x -> x
+  | None -> invalid_arg "CCOpt.get_exn"
+
+let getLazy defaultFn x = match x with
+  | None -> defaultFn ()
+  | Some y -> y
+  
+
+let forEach f o = match o with
+  | None -> ()
+  | Some x -> f x
+
+let map f = function
+  | None -> None
+  | Some x -> Some (f x)
+
+let mapOr ~default f = function
+  | None -> default
+  | Some x -> f x
+
+(* mapOrLazy *)
+
+let maybe f default = mapOr ~default f
+
+let map2 f o1 o2 = match o1, o2 with
+  | None, _
+  | _, None -> None
+  | Some x, Some y -> Some (f x y)
+
+let flatMap f o = match o with
+  | None -> None
+  | Some x -> f x
+
+let reduce f acc o = match o with
+  | None -> acc
+  | Some x -> f acc x
+
+let filter p = function
+  | Some x as o when p x -> o
+  | o -> o
+
+
+let apply f x = match f, x with
+  | None, _
+  | _, None -> None
+  | Some f, Some x -> Some (f x)
+
+
+(* and_ *)
+
+let andThen o f = match o with
+  | None -> None
+  | Some x -> f x
+
+
+let or_ b = function
+  | None -> b
+  | Some _ as a -> a
+
+(* orLazy *)
+
+let any l = List.fold_right or_ l None
+
+
+let exists p = function
+  | None -> false
+  | Some x -> p x
+
+let forAll p = function
+  | None -> true
+  | Some x -> p x
+
+
+(* okOr *)
+
+(* okOrLazy *)
+
+let toList o = match o with
   | None -> []
   | Some x -> [x]
 
-let of_list = function
-  | x::_ -> Some x
-  | [] -> None
-
-module Infix = struct
-  let (>|=) = (>|=)
-  let (>>=) = (>>=)
-  let (<*>) = (<*>)
-  let (<$>) = (<$>)
-  let (<+>) = (<+>)
-end
-
 type 'a sequence = ('a -> unit) -> unit
-type 'a gen = unit -> 'a option
-type 'a printer = Format.formatter -> 'a -> unit
-type 'a random_gen = Random.State.t -> 'a
-
-let random g st =
-  if Random.State.bool st then Some (g st) else None
-
-exception ExitChoice
-
-let choice_seq s =
-  let r = ref None in
-  begin try
-      s (function
-        | None -> ()
-        | (Some _) as o -> r := o; raise ExitChoice
-      )
-    with ExitChoice -> ()
-  end;
-  !r
-
-(*$T
-  choice_seq (Sequence.of_list [None; Some 1; Some 2]) = Some 1
-  choice_seq Sequence.empty = None
-  choice_seq (Sequence.repeat None |> Sequence.take 100) = None
-*)
-
-let to_gen o =
-  match o with
-    | None -> (fun () -> None)
-    | Some _ ->
-      let first = ref true in
-      fun () -> if !first then (first:=false; o) else None
-
-let to_seq o k = match o with
+let toSeq o k = match o with
   | None -> ()
   | Some x -> k x
-
-let pp ppx out = function
-  | None -> Format.pp_print_string out "None"
-  | Some x -> Format.fprintf out "@[Some %a@]" ppx x

--- a/src/bopt.ml
+++ b/src/bopt.ml
@@ -56,9 +56,9 @@ let equal f o1 o2 = match o1, o2 with
   | Some x, Some y -> f x y
 
 let compare f o1 o2 = match o1, o2 with
-  | None, None -> 0
-  | Some _, None -> 1
-  | None, Some _ -> -1
+  | None, None -> Comparison.Equal
+  | Some _, None -> Comparison.Greater
+  | None, Some _ -> Comparison.Less
   | Some x, Some y -> f x y
 
 

--- a/src/bopt.ml
+++ b/src/bopt.ml
@@ -112,7 +112,7 @@ let reduce f acc o = match o with
 
 let filter p o = match o with
   | Some x when p x -> o
-  | _ -> o
+  | _ -> None
 
 
 let apply f x = match f, x with

--- a/src/bopt.ml
+++ b/src/bopt.ml
@@ -134,6 +134,14 @@ let orLazy ~else_ a = match a with
   | None -> else_ ()
   | Some _ -> a
 
+let flatten = function
+  | Some a -> a
+  | None -> None
+
+let zip a b = match a, b with
+  | (Some x, Some y) -> Some (x, y)
+  | _ -> None
+
 let any l = List.fold_left (fun a b -> or_ ~else_:b a) None l
 
 

--- a/src/bopt.ml
+++ b/src/bopt.ml
@@ -125,20 +125,16 @@ let and_ o = function
   | None -> None
   | Some _ -> o
 
-let andThen f o = match o with
-  | None -> None
-  | Some x -> f x
 
-
-let or_ b a = match a with
-  | None -> b
+let or_ ~else_ a = match a with
+  | None -> else_
   | Some _ -> a
 
-let orLazy orFn a = match a with
-  | None -> orFn ()
+let orLazy ~else_ a = match a with
+  | None -> else_ ()
   | Some _ -> a
 
-let any l = List.fold_right or_ l None
+let any l = List.fold_left (fun a b -> or_ ~else_:b a) None l
 
 
 let exists p = function

--- a/src/bopt.ml
+++ b/src/bopt.ml
@@ -91,7 +91,9 @@ let mapOr ~default f = function
   | None -> default
   | Some x -> f x
 
-(* mapOrLazy *)
+let mapOrLazy ~default f = function
+  | None -> default ()
+  | Some x -> f x
 
 let maybe f default = mapOr ~default f
 
@@ -108,8 +110,8 @@ let reduce f acc o = match o with
   | None -> acc
   | Some x -> f acc x
 
-let filter p = function
-  | Some x as o when p x -> o
+let filter p o = match o with
+  | Some x when p x -> o
   | o -> o
 
 
@@ -119,18 +121,22 @@ let apply f x = match f, x with
   | Some f, Some x -> Some (f x)
 
 
-(* and_ *)
+let and_ o = function
+  | None -> None
+  | Some _ -> o
 
-let andThen o f = match o with
+let andThen f o = match o with
   | None -> None
   | Some x -> f x
 
 
-let or_ b = function
+let or_ b a = match a with
   | None -> b
-  | Some _ as a -> a
+  | Some _ -> a
 
-(* orLazy *)
+let orLazy orFn a = match a with
+  | None -> orFn ()
+  | Some _ -> a
 
 let any l = List.fold_right or_ l None
 
@@ -144,9 +150,13 @@ let forAll p = function
   | Some x -> p x
 
 
-(* okOr *)
+let okOr e = function
+  | Some x -> Result.Ok x
+  | None -> Result.Error e
 
-(* okOrLazy *)
+let okOrLazy errFn = function
+  | Some x -> Result.Ok x
+  | None -> Result.Error (errFn ())
 
 let toList o = match o with
   | None -> []

--- a/src/bopt.ml
+++ b/src/bopt.ml
@@ -7,11 +7,11 @@ TODO:
 - [x] Use `camelCase` instead of `snake_case`
 - [x] Get rid of scary monadic and math-y terminology
 - [x] Follow the conventions used in the `Js.*` modules
-- [ ] Type functions correctly, e.g. `compare` should return a proper variant, not `0`, `1` or `-1`
+- [x] Type functions correctly, e.g. `compare` should return a proper variant, not `0`, `1` or `-1`
 - [x] Remove operators and aliases, e.g. `pure` as an alias for `return`
 - [x] Remove the use of exceptions for internal logic (maybe? seems very sketchy to me but perhaps there's a really really good reason, see [this example](https://github.com/BuckleTypes/bs-containers/blob/master/src/bopt.ml#L163))
 - [x] Replace `Format.printf` calls, they pull in a lot stuff for little benefit
-- [ ] Document everything properly, with examples
+- [/] Document everything properly, with examples
 - [ ] Add tests for everything
 *)
 
@@ -49,24 +49,24 @@ let isNone = function
   | None -> true
   | Some _ -> false
 
-let equal f o1 o2 = match o1, o2 with
+let equal f a b = match a, b with
   | None, None -> true
   | Some _, None
   | None, Some _ -> false
   | Some x, Some y -> f x y
 
-let compare f o1 o2 = match o1, o2 with
+let compare f a b = match a, b with
   | None, None -> Comparison.Equal
   | Some _, None -> Comparison.Greater
   | None, Some _ -> Comparison.Less
   | Some x, Some y -> f x y
 
 
-let get default x = match x with
+let get default = function
   | None -> default
   | Some y -> y
 
-let getOr ~default x = match x with
+let getOr ~default = function
   | None -> default
   | Some y -> y
 
@@ -74,12 +74,12 @@ let getOrRaise = function
   | Some x -> x
   | None -> invalid_arg "CCOpt.get_exn"
 
-let getLazy defaultFn x = match x with
+let getLazy defaultFn = function
   | None -> defaultFn ()
   | Some y -> y
   
 
-let forEach f o = match o with
+let forEach f = function
   | None -> ()
   | Some x -> f x
 
@@ -97,33 +97,33 @@ let mapOrLazy ~default f = function
 
 let maybe f default = mapOr ~default f
 
-let map2 f o1 o2 = match o1, o2 with
+let map2 f a b = match a, b with
   | None, _
   | _, None -> None
   | Some x, Some y -> Some (f x y)
 
-let flatMap f o = match o with
+let flatMap f = function
   | None -> None
   | Some x -> f x
 
-let reduce f acc o = match o with
+let reduce f acc = function
   | None -> acc
   | Some x -> f acc x
 
-let filter p o = match o with
-  | Some x when p x -> o
+let filter p a = match a with
+  | Some x when p x -> a
   | _ -> None
 
 
-let apply f x = match f, x with
+let apply f a = match f, a with
   | None, _
   | _, None -> None
   | Some f, Some x -> Some (f x)
 
 
-let and_ o = function
+let and_ b = function
   | None -> None
-  | Some _ -> o
+  | Some _ -> b
 
 
 let or_ ~else_ a = match a with
@@ -154,7 +154,7 @@ let okOrLazy errFn = function
   | Some x -> Result.Ok x
   | None -> Result.Error (errFn ())
 
-let toList o = match o with
+let toList = function
   | None -> []
   | Some x -> [x]
 

--- a/src/bopt.mli
+++ b/src/bopt.mli
@@ -4,129 +4,153 @@
 (** {1 Options} *)
 
 type +'a t = 'a option
+(** alias of the standard [option] type *)
 
 (** {2 Construction} *)
 
 (* was return *)
 val make : 'a -> 'a t
-(** Monadic return, that is [return x = Some x] *)
+(** [make x] is [Some x] *)
 
 val fromList : 'a list -> 'a t
-(** Head of list, or [None] *)
+(** [fromList l] is [Some x] is [l] is [x :: _], [None] otherwise (ie. if [l] is
+    [\[\]]) *)
 
 val if_ : ('a -> bool) -> 'a -> 'a option
-(** [if_ f x] is [Some x] if [f x], [None] otherwise
-    @since 0.17 *)
+(** [if_ f x] is [Some x] if [f x], [None] otherwise *)
 
 val wrap : ?handler:(exn -> bool) -> ('a -> 'b) -> 'a -> 'b option
-(** [wrap f x] calls [f x] and returns [Some y] if [f x = y]. If [f x] raises
-    any exception, the result is [None]. This can be useful to wrap functions
-    such as [Map.S.find].
+(** [wrap f x] is [Some (f x)] if [f x] does not raise an exception, [None] if
+    it does and [handler e] is [true], otherwise reraises the exception.
+
     @param handler the exception handler, which returns [true] if the
-        exception is to be caught. *)
+        exception is to be caught.
+*)
 
 val wrap2 : ?handler:(exn -> bool) -> ('a -> 'b -> 'c) -> 'a -> 'b -> 'c option
-(** [wrap2 f x y] is similar to {!wrap1} but for binary functions. *)
+(** [wrap2 f x y] is [Some (f x y)] if [f x y] does not raise an exception,
+    [None] if it does and [handler e] is [true], otherwise reraises the exception.
+
+    @param handler the exception handler, which returns [true] if the
+        exception is to be caught.
+*)
 
 (** {2 Comparison} *)
 
 val isSome : _ t -> bool
+(** [isSome a] is [true] if [a] is [Some _], [false] otherwise *)
 
 val isNone : _ t -> bool
-(** @since 0.11 *)
+(** [isNone a] is [true] if [a] is [None], [false] otherwise *)
 
 val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+(** [equal f a b] is [true] if both are [None], [f x y] if both are [Some _],
+    [false] otherwise *)
 
 val compare : ('a -> 'a -> Comparison.comparison) -> 'a t -> 'a t -> Comparison.comparison
+(** [compare f a b] is [Equal] if both are [None], [f x y] if both are [Some _],
+    [Greater] if [a] is [Some _] and [b] is [None], [Less] if vice versa. *)
 
 (** {2 Access} *)
 
 val get : 'a -> 'a option -> 'a
+(** [get default a] is [x] if [a] is [Some x], [default] otherwise *)
 
 val getOr : default:'a -> 'a t -> 'a
-(** [getOr ~default o] extracts the value from [o], or
-    returns [default] if [o = None].
-    @since 0.18 *)
+(** [getOr ~default a] is [x] if [a] is [Some x], [default] otherwise *)
 
 val getOrRaise : 'a t -> 'a
-(** Open the option, possibly failing if it is [None]
-    @raise Invalid_argument if the option is [None] *)
+(** [getOrRaise a] is [x] if [a] is [Some x], raises [Invalid_argument] otherwise
+
+    @raise Invaliud_argument if given option is None    
+*)
 
 val getLazy : (unit -> 'a) -> 'a t -> 'a
-(** [get_lazy defaultn x] unwraps [x], but if [x = None] it returns [default_fn ()] instead.
-    @since 0.6.1 *)
+(** [getLazy defaultFn a] is [x] if [a] is [Some x], [defaultFn ()] otherwise *)
 
 (** {2 Iteration} *)
 
 val forEach : ('a -> unit) -> 'a t -> unit
-(** Iterate on 0 or 1 element *)
+(** [forEach f a] calls [f x] if [a] is [Some x] *)
 
 val map : ('a -> 'b) -> 'a t -> 'b t
-(** Transform the element inside, if any *)
+(** [map f a] is [Some (f x)] if [a] is [Some x], [None] otherwise *)
 
 val mapOr : default:'b -> ('a -> 'b) -> 'a t -> 'b
-(** [map_or ~default f o] is [f x] if [o = Some x], [default otherwise]
-    @since 0.16 *)
+(** [mapOr ~default f a] is [Some (f x)] if [a] is [Some x], [default] otherwise *)
 
 (* new *)
 val mapOrLazy : default:(unit -> 'b) -> ('a -> 'b) -> 'a t -> 'b
+(** [mapOrLazy ~default f a] is [Some (f x)] if [a] is [Some x], [default ()]
+    otherwise *)
 
-val maybe : ('a -> 'b) -> 'b -> 'a option -> 'b
+val maybe : ('a -> 'b) -> 'b -> 'a t -> 'b
+(** [maybe f default a] is [Some (f x)] if [a] is [Some x], [default] otherwise *)
 
 val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+(** [map2 f a b] is [Some (f x y)] if [a] is [Some x], and [b] is [Some y],
+    [None] otherwise *)
 
 (* alternative name: andThen *)
 val flatMap : ('a -> 'b t) -> 'a t -> 'b t
-(** Flip version of {!>>=} *)
+(** [flatMap f a] is [f x] is [a] is [Some x], [None] otherwise *)
 
 val reduce : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
-(** reduce on 0 or 1 element *)
+(** [reduce f initial a] is [f inital x] if [a] is [Some x], [initial] otherwise *)
 
 val filter : ('a -> bool) -> 'a t -> 'a t
-(** Filter on 0 or 1 element
-    @since 0.5 *)
+(** [filter f a] is [a] if [a] is [Some x] and [f x] is [true], [None] otherwise *)
 
 (** {2 Applicative} *)
 
 (* was (<*>) *)
 val apply : ('a -> 'b) t -> 'a t -> 'b t
+(** [apply maybeF a] is [Some (f x)] if [maybeF) is [Some f] and [a] is [Some x],
+    [None] otherwise *)
 
 (** {2 Sequencing} *)
 
 (* new *)
 val and_ : 'b t -> 'a t -> 'b t
+(** [and_ a b] is [b] if [a] is [Some _], [None] otherwise *)
 
 (** {2 Alternatives} *)
 
 (* was (<+>) *)
 val or_ : else_:'a t -> 'a t -> 'a t
-(** [or_ ~else_ a] is [a] if [a] is [Some _], [b] otherwise *)
+(** [or_ ~else_ a] is [a] if [a] is [Some _], [else_] otherwise *)
 
 (* new *)
 val orLazy : else_:(unit -> 'a t) -> 'a t -> 'a t
+(** [orLazy ~else_ a] is [a] if [a] is [Some _], [else_ ()] otherwise *)
 
 (* was choice *)
 val any : 'a t list -> 'a t
-(** [choice] returns the first non-[None] element of the list, or [None] *)
+(** [choice l] returns the first non-[None] element of the list if it exists,
+    [None] otherwise *)
 
 (** {2 Quantification} *)
 (** TODO: too mathy? *)
 
 val exists : ('a -> bool) -> 'a t -> bool
-(** @since 0.17 *)
+(** [exists f a] is [f x] if [a] is [Some x], [false] otherwise *)
 
 val forAll : ('a -> bool) -> 'a t -> bool
-(** @since 0.17 *)
+(** [forAll f a] is [f x] if [a] is [Some x], [true] otherwise *)
 
 (** {2 Conversion and IO} *)
 
 (* new *)
 val okOr : 'e -> 'a t -> ('a, 'e) Result.result
+(** [okOr e a] is [Ok x] if [a] is [Some x], [Error e] otherwise *)
 
 (* new *)
 val okOrLazy : (unit -> 'e) -> 'a t -> ('a, 'e) Result.result
+(** [okOr errorFn a] is [Ok x] if [a] is [Some x], [Error (errorFn ())] otherwise *)
 
 val toList : 'a t -> 'a list
+(** [toList a] is [\[x\]] if [a] is [Some x], [\[\]] otherwise *)
 
 type 'a sequence = ('a -> unit) -> unit
 val toSeq : 'a t -> 'a sequence
+(** [toSeq a] returns a sequence of [x] if a is [Some x], empty sequence otherwise *)

--- a/src/bopt.mli
+++ b/src/bopt.mli
@@ -5,77 +5,18 @@
 
 type +'a t = 'a option
 
-val map : ('a -> 'b) -> 'a t -> 'b t
-(** Transform the element inside, if any *)
+(** {2 Construction} *)
 
-val map_or : default:'b -> ('a -> 'b) -> 'a t -> 'b
-(** [map_or ~default f o] is [f x] if [o = Some x], [default otherwise]
-    @since 0.16 *)
-
-val maybe : ('a -> 'b) -> 'b -> 'a option -> 'b
-
-val is_some : _ t -> bool
-
-val is_none : _ t -> bool
-(** @since 0.11 *)
-
-val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
-
-val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
-
-val return : 'a -> 'a t
+(* was return *)
+val make : 'a -> 'a t
 (** Monadic return, that is [return x = Some x] *)
 
-val (>|=) : 'a t -> ('a -> 'b) -> 'b t
-(** Infix version of {!map} *)
-
-val (>>=) : 'a t -> ('a -> 'b t) -> 'b t
-(** Monadic bind *)
-
-val flat_map : ('a -> 'b t) -> 'a t -> 'b t
-(** Flip version of {!>>=} *)
-
-val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
-
-val iter : ('a -> unit) -> 'a t -> unit
-(** Iterate on 0 or 1 element *)
-
-val fold : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
-(** Fold on 0 or 1 element *)
-
-val get : 'a -> 'a option -> 'a
-
-val filter : ('a -> bool) -> 'a t -> 'a t
-(** Filter on 0 or 1 element
-    @since 0.5 *)
+val fromList : 'a list -> 'a t
+(** Head of list, or [None] *)
 
 val if_ : ('a -> bool) -> 'a -> 'a option
 (** [if_ f x] is [Some x] if [f x], [None] otherwise
     @since 0.17 *)
-
-val exists : ('a -> bool) -> 'a t -> bool
-(** @since 0.17 *)
-
-val for_all : ('a -> bool) -> 'a t -> bool
-(** @since 0.17 *)
-
-val get_or : default:'a -> 'a t -> 'a
-(** [get_or ~default o] extracts the value from [o], or
-    returns [default] if [o = None].
-    @since 0.18 *)
-
-val get_exn : 'a t -> 'a
-(** Open the option, possibly failing if it is [None]
-    @raise Invalid_argument if the option is [None] *)
-
-val get_lazy : (unit -> 'a) -> 'a t -> 'a
-(** [get_lazy default_fn x] unwraps [x], but if [x = None] it returns [default_fn ()] instead.
-    @since 0.6.1 *)
-
-val sequence_l : 'a t list -> 'a list t
-(** [sequence_l [x1; x2; ...; xn]] returns [Some [y1;y2;...;yn]] if
-    every [xi] is [Some yi]. Otherwise, if the list contains at least
-    one [None], the result is [None]. *)
 
 val wrap : ?handler:(exn -> bool) -> ('a -> 'b) -> 'a -> 'b option
 (** [wrap f x] calls [f x] and returns [Some y] if [f x = y]. If [f x] raises
@@ -87,54 +28,108 @@ val wrap : ?handler:(exn -> bool) -> ('a -> 'b) -> 'a -> 'b option
 val wrap2 : ?handler:(exn -> bool) -> ('a -> 'b -> 'c) -> 'a -> 'b -> 'c option
 (** [wrap2 f x y] is similar to {!wrap1} but for binary functions. *)
 
+(** {2 Comparison} *)
+
+val isSome : _ t -> bool
+
+val isNone : _ t -> bool
+(** @since 0.11 *)
+
+val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
+
+(** {2 Access} *)
+
+val get : 'a -> 'a option -> 'a
+
+val getOr : default:'a -> 'a t -> 'a
+(** [getOr ~default o] extracts the value from [o], or
+    returns [default] if [o = None].
+    @since 0.18 *)
+
+val getOrRaise : 'a t -> 'a
+(** Open the option, possibly failing if it is [None]
+    @raise Invalid_argument if the option is [None] *)
+
+val getLazy : (unit -> 'a) -> 'a t -> 'a
+(** [get_lazy defaultn x] unwraps [x], but if [x = None] it returns [default_fn ()] instead.
+    @since 0.6.1 *)
+
+(** {2 Iteration} *)
+
+val forEach : ('a -> unit) -> 'a t -> unit
+(** Iterate on 0 or 1 element *)
+
+val map : ('a -> 'b) -> 'a t -> 'b t
+(** Transform the element inside, if any *)
+
+val mapOr : default:'b -> ('a -> 'b) -> 'a t -> 'b
+(** [map_or ~default f o] is [f x] if [o = Some x], [default otherwise]
+    @since 0.16 *)
+
+(* new *)
+val mapOrLazy : default:(unit -> 'b) -> ('a -> 'b) -> 'a t -> 'b
+
+val maybe : ('a -> 'b) -> 'b -> 'a option -> 'b
+
+val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+
+val flatMap : ('a -> 'b t) -> 'a t -> 'b t
+(** Flip version of {!>>=} *)
+
+val reduce : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
+(** reduce on 0 or 1 element *)
+
+val filter : ('a -> bool) -> 'a t -> 'a t
+(** Filter on 0 or 1 element
+    @since 0.5 *)
+
 (** {2 Applicative} *)
 
-val pure : 'a -> 'a t
-(** Alias to {!return} *)
+(* was (<*>) *)
+val apply : ('a -> 'b) t -> 'a t -> 'b t
 
-val (<*>) : ('a -> 'b) t -> 'a t -> 'b t
+(** {2 Sequencing} *)
 
-val (<$>) : ('a -> 'b) -> 'a t -> 'b t
+(* new *)
+val and_ : 'b t -> 'a t -> 'b t
+
+(* was (>>=) *)
+val andThen : ('a -> 'b t) -> 'a t -> 'b t
+(** Monadic bind *)
 
 (** {2 Alternatives} *)
 
-val (<+>) : 'a t -> 'a t -> 'a t
+(* was (<+>) *)
+val or_ : 'a t -> 'a t -> 'a t
 (** [a <+> b] is [a] if [a] is [Some _], [b] otherwise *)
 
-val choice : 'a t list -> 'a t
+(* new *)
+val orLazy : (unit -> 'a t) -> 'a t -> 'a t
+
+(* was choice *)
+val any : 'a t list -> 'a t
 (** [choice] returns the first non-[None] element of the list, or [None] *)
 
-(** {2 Infix Operators}
-    @since 0.16 *)
+(** {2 Quantification} *)
+(** TODO: too mathy? *)
 
-module Infix : sig
-  val (>|=) : 'a t -> ('a -> 'b) -> 'b t
-  val (>>=) : 'a t -> ('a -> 'b t) -> 'b t
-  val (<*>) : ('a -> 'b) t -> 'a t -> 'b t
-  val (<$>) : ('a -> 'b) -> 'a t -> 'b t
-  val (<+>) : 'a t -> 'a t -> 'a t
-end
+val exists : ('a -> bool) -> 'a t -> bool
+(** @since 0.17 *)
+
+val forAll : ('a -> bool) -> 'a t -> bool
+(** @since 0.17 *)
 
 (** {2 Conversion and IO} *)
 
-val to_list : 'a t -> 'a list
+(* new *)
+val okOr : 'e -> 'a t -> ('a, 'e) Result.result
 
-val of_list : 'a list -> 'a t
-(** Head of list, or [None] *)
+(* new *)
+val okOrLazy : 'e -> 'a t -> ('a, 'e) Result.result
+
+val toList : 'a t -> 'a list
 
 type 'a sequence = ('a -> unit) -> unit
-type 'a gen = unit -> 'a option
-type 'a printer = Format.formatter -> 'a -> unit
-type 'a random_gen = Random.State.t -> 'a
-
-val random : 'a random_gen -> 'a t random_gen
-
-val choice_seq : 'a t sequence -> 'a t
-(** [choice_seq s] is similar to {!choice}, but works on sequences.
-    It returns the first [Some x] occurring in [s], or [None] otherwise.
-    @since 0.13 *)
-
-val to_gen : 'a t -> 'a gen
-val to_seq : 'a t -> 'a sequence
-
-val pp : 'a printer -> 'a t printer
+val toSeq : 'a t -> 'a sequence

--- a/src/bopt.mli
+++ b/src/bopt.mli
@@ -75,6 +75,7 @@ val maybe : ('a -> 'b) -> 'b -> 'a option -> 'b
 
 val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 
+(* alternative name: andThen *)
 val flatMap : ('a -> 'b t) -> 'a t -> 'b t
 (** Flip version of {!>>=} *)
 
@@ -94,10 +95,6 @@ val apply : ('a -> 'b) t -> 'a t -> 'b t
 
 (* new *)
 val and_ : 'b t -> 'a t -> 'b t
-
-(* was (>>=) *)
-val andThen : ('a -> 'b t) -> 'a t -> 'b t
-(** Monadic bind *)
 
 (** {2 Alternatives} *)
 

--- a/src/bopt.mli
+++ b/src/bopt.mli
@@ -16,10 +16,10 @@ val fromList : 'a list -> 'a t
 (** [fromList l] is [Some x] is [l] is [x :: _], [None] otherwise (ie. if [l] is
     [\[\]]) *)
 
-val if_ : ('a -> bool) -> 'a -> 'a option
+val if_ : ('a -> bool) -> 'a -> 'a t
 (** [if_ f x] is [Some x] if [f x], [None] otherwise *)
 
-val wrap : ?handler:(exn -> bool) -> ('a -> 'b) -> 'a -> 'b option
+val wrap : ?handler:(exn -> bool) -> ('a -> 'b) -> 'a -> 'b t
 (** [wrap f x] is [Some (f x)] if [f x] does not raise an exception, [None] if
     it does and [handler e] is [true], otherwise reraises the exception.
 
@@ -27,7 +27,7 @@ val wrap : ?handler:(exn -> bool) -> ('a -> 'b) -> 'a -> 'b option
         exception is to be caught.
 *)
 
-val wrap2 : ?handler:(exn -> bool) -> ('a -> 'b -> 'c) -> 'a -> 'b -> 'c option
+val wrap2 : ?handler:(exn -> bool) -> ('a -> 'b -> 'c) -> 'a -> 'b -> 'c t
 (** [wrap2 f x y] is [Some (f x y)] if [f x y] does not raise an exception,
     [None] if it does and [handler e] is [true], otherwise reraises the exception.
 
@@ -53,7 +53,7 @@ val compare : ('a -> 'a -> Comparison.comparison) -> 'a t -> 'a t -> Comparison.
 
 (** {2 Access} *)
 
-val get : 'a -> 'a option -> 'a
+val get : 'a -> 'a t -> 'a
 (** [get default a] is [x] if [a] is [Some x], [default] otherwise *)
 
 val getOr : default:'a -> 'a t -> 'a

--- a/src/bopt.mli
+++ b/src/bopt.mli
@@ -99,11 +99,11 @@ val and_ : 'b t -> 'a t -> 'b t
 (** {2 Alternatives} *)
 
 (* was (<+>) *)
-val or_ : 'a t -> 'a t -> 'a t
-(** [a <+> b] is [a] if [a] is [Some _], [b] otherwise *)
+val or_ : else_:'a t -> 'a t -> 'a t
+(** [or_ ~else_ a] is [a] if [a] is [Some _], [b] otherwise *)
 
 (* new *)
-val orLazy : (unit -> 'a t) -> 'a t -> 'a t
+val orLazy : else_:(unit -> 'a t) -> 'a t -> 'a t
 
 (* was choice *)
 val any : 'a t list -> 'a t

--- a/src/bopt.mli
+++ b/src/bopt.mli
@@ -122,6 +122,12 @@ val or_ : else_:'a t -> 'a t -> 'a t
 val orLazy : else_:(unit -> 'a t) -> 'a t -> 'a t
 (** [orLazy ~else_ a] is [a] if [a] is [Some _], [else_ ()] otherwise *)
 
+(* new *)
+val flatten : 'a t t -> 'a t
+
+(* new *)
+val zip : 'a t -> 'b t -> ('a * 'b) t
+
 (* was choice *)
 val any : 'a t list -> 'a t
 (** [choice l] returns the first non-[None] element of the list if it exists,

--- a/src/bopt.mli
+++ b/src/bopt.mli
@@ -37,7 +37,7 @@ val isNone : _ t -> bool
 
 val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 
-val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
+val compare : ('a -> 'a -> Comparison.comparison) -> 'a t -> 'a t -> Comparison.comparison
 
 (** {2 Access} *)
 

--- a/src/bopt.mli
+++ b/src/bopt.mli
@@ -127,7 +127,7 @@ val forAll : ('a -> bool) -> 'a t -> bool
 val okOr : 'e -> 'a t -> ('a, 'e) Result.result
 
 (* new *)
-val okOrLazy : 'e -> 'a t -> ('a, 'e) Result.result
+val okOrLazy : (unit -> 'e) -> 'a t -> ('a, 'e) Result.result
 
 val toList : 'a t -> 'a list
 

--- a/src/bopt.mli
+++ b/src/bopt.mli
@@ -108,13 +108,11 @@ val apply : ('a -> 'b) t -> 'a t -> 'b t
 (** [apply maybeF a] is [Some (f x)] if [maybeF) is [Some f] and [a] is [Some x],
     [None] otherwise *)
 
-(** {2 Sequencing} *)
+(** {2 Composition} *)
 
 (* new *)
 val and_ : 'b t -> 'a t -> 'b t
 (** [and_ a b] is [b] if [a] is [Some _], [None] otherwise *)
-
-(** {2 Alternatives} *)
 
 (* was (<+>) *)
 val or_ : else_:'a t -> 'a t -> 'a t
@@ -138,7 +136,7 @@ val exists : ('a -> bool) -> 'a t -> bool
 val forAll : ('a -> bool) -> 'a t -> bool
 (** [forAll f a] is [f x] if [a] is [Some x], [true] otherwise *)
 
-(** {2 Conversion and IO} *)
+(** {2 Conversion} *)
 
 (* new *)
 val okOr : 'e -> 'a t -> ('a, 'e) Result.result

--- a/src/bopt.mli
+++ b/src/bopt.mli
@@ -124,9 +124,11 @@ val orLazy : else_:(unit -> 'a t) -> 'a t -> 'a t
 
 (* new *)
 val flatten : 'a t t -> 'a t
+(** [flatten a] is [Some x] if [a] is [Some (Some x)], [None] otherwise *)
 
 (* new *)
 val zip : 'a t -> 'b t -> ('a * 'b) t
+(** [zip a b] is [Some (x, y)] if [a, b] is [Some x, Some y], [None] otherwise *)
 
 (* was choice *)
 val any : 'a t list -> 'a t

--- a/src/comparison.ml
+++ b/src/comparison.ml
@@ -1,0 +1,10 @@
+type comparison =
+  | Greater
+  | Less
+  | Equal
+
+let compare a b = match Pervasives.compare a b with
+  | 0 -> Equal
+  | -1 -> Less
+  | 1 -> Greater
+  | _ -> assert false

--- a/src/comparison.mli
+++ b/src/comparison.mli
@@ -1,4 +1,0 @@
-type comparison =
-  | Greater
-  | Less
-  | Equal

--- a/src/comparison.mli
+++ b/src/comparison.mli
@@ -1,0 +1,4 @@
+type comparison =
+  | Greater
+  | Less
+  | Equal

--- a/test/__tests__/bopt_test.ml
+++ b/test/__tests__/bopt_test.ml
@@ -116,33 +116,33 @@ let _ =
     forEach (fun _ -> fail t) None);
 
   test "map - Some _" (fun t ->
-    deepEqual t (map (( *) 3) (Some 7)) (Some 21));
+    deepEqual t (map (( * ) 3) (Some 7)) (Some 21));
   test "map - None" (fun t ->
-    deepEqual t (map (( *) 3) None) None);
+    deepEqual t (map (( * ) 3) None) None);
 
   test "mapOr - Some _" (fun t ->
-    deepEqual t (mapOr ~default:42 (( *) 3) (Some 7)) 21);
+    deepEqual t (mapOr ~default:42 (( * ) 3) (Some 7)) 21);
   test "mapOr - None" (fun t ->
-    deepEqual t (mapOr ~default:42 (( *) 3) None) 42);
+    deepEqual t (mapOr ~default:42 (( * ) 3) None) 42);
 
   test "mapiOrLazy - Some _" (fun t ->
-    deepEqual t (mapOrLazy ~default:(fun () -> 42) (( *) 3) (Some 7)) 21);
+    deepEqual t (mapOrLazy ~default:(fun () -> 42) (( * ) 3) (Some 7)) 21);
   test "mapOrLazy - None" (fun t ->
-    deepEqual t (mapOrLazy ~default:(fun () -> 42) (( *) 3) None) 42);
+    deepEqual t (mapOrLazy ~default:(fun () -> 42) (( * ) 3) None) 42);
 
   test "maybe - Some _" (fun t ->
-    deepEqual t (maybe (( *) 3) 42 (Some 7)) 21);
+    deepEqual t (maybe (( * ) 3) 42 (Some 7)) 21);
   test "maybe - None" (fun t ->
-    deepEqual t (maybe (( *) 3) 42 None) 42);
+    deepEqual t (maybe (( * ) 3) 42 None) 42);
 
   test "map2 - Some a, Some b" (fun t ->
-    deepEqual t (map2 ( *) (Some 7) (Some 5)) (Some 35));
+    deepEqual t (map2 ( * ) (Some 7) (Some 5)) (Some 35));
   test "map2 - Some a, None" (fun t ->
-    deepEqual t (map2 ( *) (Some 5) None) None);
+    deepEqual t (map2 ( * ) (Some 5) None) None);
   test "map2 - None, Some b" (fun t ->
-    deepEqual t (map2 ( *) None (Some 5)) None);
+    deepEqual t (map2 ( * ) None (Some 5)) None);
   test "map2 - None, None" (fun t ->
-    deepEqual t (map2 ( *) None None) None);
+    deepEqual t (map2 ( * ) None None) None);
 
   test "flatMap - Some _ -> Some _" (fun t ->
     deepEqual t (flatMap (fun x -> Some (x * 4)) (Some 7)) (Some 28));
@@ -164,9 +164,9 @@ let _ =
     deepEqual t (filter (fun _ -> true) None) None);
 
   test "apply - Some f, Some x" (fun t ->
-    deepEqual t (apply (Some (( *) 3)) (Some 7)) (Some 21));
+    deepEqual t (apply (Some (( * ) 3)) (Some 7)) (Some 21));
   test "apply - Some f, None" (fun t ->
-    deepEqual t (apply (Some (( *) 3)) None) None);
+    deepEqual t (apply (Some (( * ) 3)) None) None);
   test "apply - None, Some x" (fun t ->
     deepEqual t (apply None (Some 7)) None);
   test "apply - None, None" (fun t ->

--- a/test/__tests__/bopt_test.ml
+++ b/test/__tests__/bopt_test.ml
@@ -3,4 +3,261 @@ open Bopt
 
 let _ =
   test "make" (fun t ->
-    deepEqual t (make 42) (Some 42))
+    deepEqual t (make 42) (Some 42));
+
+  test "fromList - []" (fun t ->
+    deepEqual t (fromList []) None);
+  test "fromList - [\"a\"]" (fun t ->
+    deepEqual t (fromList ["a"]) (Some "a"));
+  test "fromList - [1;2;3]" (fun t ->
+    deepEqual t (fromList [1;2;3]) (Some 1));
+
+  test "if_ - f = true" (fun t ->
+    deepEqual t (if_ (fun x -> x = 2) 2) (Some 2));
+  test "if_ - f = false" (fun t ->
+    deepEqual t (if_ (fun x -> x = 3) 2) (None));
+
+  test "wrap - raise" (fun t ->
+    deepEqual t
+      (wrap (fun _ -> raise (Invalid_argument "")) 2) (None));
+  test "wrap - raise, handler = true" (fun t ->
+    let handler = function | Invalid_argument _ -> true | _ -> false in
+    deepEqual t
+      (wrap ~handler (fun _ -> raise (Invalid_argument "")) 2) (None));
+  test "wrap - raise, handler = false" (fun t ->
+    let handler = function | Invalid_argument _ -> false | _ -> true in
+    try 
+      ignore @@ wrap ~handler (fun _ -> raise (Invalid_argument "")) 2;
+      fail t
+    with
+      | Invalid_argument _ -> pass t);
+  test "wrap - no raise" (fun t ->
+    deepEqual t
+      (wrap ((+) 3) 2) (Some 5));
+
+  test "wrap2 - raise" (fun t ->
+    deepEqual t
+      (wrap2 (fun _ _ -> raise (Invalid_argument "")) 2 7) (None));
+  test "wrap2 - raise, handler = true" (fun t ->
+    let handler = function | Invalid_argument _ -> true | _ -> false in
+    deepEqual t
+      (wrap2 ~handler (fun _ _ -> raise (Invalid_argument "")) 2 7) (None));
+  test "wrap2 - raise, handler = false" (fun t ->
+    let handler = function | Invalid_argument _ -> false | _ -> true in
+    try 
+      ignore @@ wrap2 ~handler (fun _ _ -> raise (Invalid_argument "")) 2 7;
+      fail t
+    with
+      | Invalid_argument _ -> pass t);
+  test "wrap2 - no raise" (fun t ->
+    deepEqual t
+      (wrap2 (+) 2 7) (Some 9));
+
+  test "isSome - Some _" (fun t ->
+    deepEqual t (isSome (Some 2)) true);
+  test "isSome - None" (fun t ->
+    deepEqual t (isSome None) false);
+
+  test "isNone - Some _" (fun t ->
+    deepEqual t (isNone (Some 2)) false);
+  test "isNone - None" (fun t ->
+    deepEqual t (isNone None) true);
+
+  test "equal - =, Some _ = Some _" (fun t ->
+    deepEqual t (equal (=) (Some 2) (Some 2)) true);
+  test "equal - <>, Some _ <> Some _" (fun t ->
+    deepEqual t (equal (<>) (Some 2) (Some 2)) false);
+  test "equal - <>, Some _ <> None" (fun t ->
+    deepEqual t (equal (<>) (Some 2) None) false);
+  test "equal - <>, None <> Some _" (fun t ->
+    deepEqual t (equal (<>) None (Some 2)) false);
+  test "equal - <>, None = None" (fun t ->
+    deepEqual t (equal (<>) None None) true);
+
+  test "compare - Some _ = Some _" (fun t ->
+    deepEqual t (compare Comparison.compare (Some 2) (Some 2)) Equal);
+  test "compare - Some _ < Some _" (fun t ->
+    deepEqual t (compare Comparison.compare (Some 2) (Some 3)) Less);
+  test "compare - Some _ > None" (fun t ->
+    deepEqual t (compare Comparison.compare (Some 2) None) Greater);
+  test "comapre - None < Some _" (fun t ->
+    deepEqual t (compare Comparison.compare None (Some 2)) Less);
+  test "compare - None = None" (fun t ->
+    deepEqual t (compare Comparison.compare None None) Equal);
+
+  test "get - Some _" (fun t ->
+    deepEqual t (get "b" (Some "a")) "a");
+  test "get - None" (fun t ->
+    deepEqual t (get "b" None) "b");
+  
+  test "getOr - Some _" (fun t ->
+    deepEqual t (getOr ~default:"b" (Some "a")) "a");
+  test "getOr - None" (fun t ->
+    deepEqual t (getOr ~default:"b" None) "b");
+
+  test "getOrRaise - Some _" (fun t ->
+    deepEqual t (getOrRaise (Some "a")) "a");
+  test "getOrRaise - None" (fun t ->
+    try
+      ignore @@ getOrRaise None;
+      fail t
+    with
+      | _ -> pass t);
+
+  test "getLazy - Some _" (fun t ->
+    deepEqual t (getLazy  (fun () -> "b") (Some "a")) "a");
+  test "getLazy - None" (fun t ->
+    deepEqual t (getLazy (fun () -> "b") None) "b");
+
+  test "forEach - Some _" (fun t ->
+    plan t 1;
+    forEach (fun x -> deepEqual t x "a") (Some "a"));
+  test "forEach - None" (fun t ->
+    forEach (fun _ -> fail t) None);
+
+  test "map - Some _" (fun t ->
+    deepEqual t (map (( *) 3) (Some 7)) (Some 21));
+  test "map - None" (fun t ->
+    deepEqual t (map (( *) 3) None) None);
+
+  test "mapOr - Some _" (fun t ->
+    deepEqual t (mapOr ~default:42 (( *) 3) (Some 7)) 21);
+  test "mapOr - None" (fun t ->
+    deepEqual t (mapOr ~default:42 (( *) 3) None) 42);
+
+  test "mapiOrLazy - Some _" (fun t ->
+    deepEqual t (mapOrLazy ~default:(fun () -> 42) (( *) 3) (Some 7)) 21);
+  test "mapOrLazy - None" (fun t ->
+    deepEqual t (mapOrLazy ~default:(fun () -> 42) (( *) 3) None) 42);
+
+  test "maybe - Some _" (fun t ->
+    deepEqual t (maybe (( *) 3) 42 (Some 7)) 21);
+  test "maybe - None" (fun t ->
+    deepEqual t (maybe (( *) 3) 42 None) 42);
+
+  test "map2 - Some a, Some b" (fun t ->
+    deepEqual t (map2 ( *) (Some 7) (Some 5)) (Some 35));
+  test "map2 - Some a, None" (fun t ->
+    deepEqual t (map2 ( *) (Some 5) None) None);
+  test "map2 - None, Some b" (fun t ->
+    deepEqual t (map2 ( *) None (Some 5)) None);
+  test "map2 - None, None" (fun t ->
+    deepEqual t (map2 ( *) None None) None);
+
+  test "flatMap - Some _ -> Some _" (fun t ->
+    deepEqual t (flatMap (fun x -> Some (x * 4)) (Some 7)) (Some 28));
+  test "flatMap - Some _ -> None" (fun t ->
+    deepEqual t (flatMap (fun _ -> None) (Some 7)) None);
+  test "flatMap - None" (fun t ->
+    deepEqual t (flatMap (fun x -> Some (x * 4)) None) None);
+
+  test "reduce - Some _" (fun t ->
+    deepEqual t (reduce (+) 6 (Some 7)) 13);
+  test "reduce - None" (fun t ->
+    deepEqual t (reduce (+) 6 None) 6);
+
+  test "filter - Some x, f x = true" (fun t ->
+    deepEqual t (filter ((=) 3) (Some 3)) (Some 3));
+  test "filter - Some x, f x = false" (fun t ->
+    deepEqual t (filter (fun _ -> false) (Some 3)) None);
+  test "filter - None" (fun t ->
+    deepEqual t (filter (fun _ -> true) None) None);
+
+  test "apply - Some f, Some x" (fun t ->
+    deepEqual t (apply (Some (( *) 3)) (Some 7)) (Some 21));
+  test "apply - Some f, None" (fun t ->
+    deepEqual t (apply (Some (( *) 3)) None) None);
+  test "apply - None, Some x" (fun t ->
+    deepEqual t (apply None (Some 7)) None);
+  test "apply - None, None" (fun t ->
+    deepEqual t (apply None None) None);
+
+  test "and_ - Some x, Some y" (fun t ->
+    deepEqual t (and_ (Some 1) (Some 2)) (Some 1));
+  test "and_ - Some x, None" (fun t ->
+    deepEqual t (and_ (Some 1) None) None);
+  test "and_ - None, Some y" (fun t ->
+    deepEqual t (and_ None (Some 2)) None);
+  test "and_ - None, None" (fun t ->
+    deepEqual t (and_ None None) None);
+
+  test "or_ - Some x, Some y" (fun t ->
+    deepEqual t (or_ ~else_:(Some 1) (Some 2)) (Some 2));
+  test "or_ - Some x, None" (fun t ->
+    deepEqual t (or_ ~else_:(Some 1) None) (Some 1));
+  test "or_ - None, Some y" (fun t ->
+    deepEqual t (or_ ~else_:None (Some 2)) (Some 2));
+  test "or_ - None, None" (fun t ->
+    deepEqual t (or_ ~else_:None None) None);
+
+  test "orLazy - Some x, Some y" (fun t ->
+    deepEqual t (orLazy ~else_:(fun () -> (Some 1)) (Some 2)) (Some 2));
+  test "orLazy - Some x, None" (fun t ->
+    deepEqual t (orLazy ~else_:(fun () -> (Some 1)) None) (Some 1));
+  test "orLazy - None, Some y" (fun t ->
+    deepEqual t (orLazy ~else_:(fun () -> None) (Some 2)) (Some 2));
+  test "orLazy - None, None" (fun t ->
+    deepEqual t (orLazy ~else_:(fun () -> None) None) None);
+
+  test "flatten  - Some (Some _)" (fun t ->
+    deepEqual t (flatten (Some (Some 3))) (Some 3));
+  test "flatten - Some None" (fun t ->
+    deepEqual t (flatten (Some None)) None);
+  test "flatten - None" (fun t ->
+    deepEqual t (flatten None) None);
+
+  test "zip - Some x, Some y" (fun t ->
+    deepEqual t (zip (Some 4) (Some 5)) (Some (4, 5)));
+  test "zip - Some x, None" (fun t ->
+    deepEqual t (zip (Some 4) None) None);
+  test "zip - None, Some x" (fun t ->
+    deepEqual t (zip None (Some 4)) None);
+  test "zip - None, None" (fun t ->
+    deepEqual t (zip None None) None);
+
+  test "any - []" (fun t ->
+    deepEqual t (any []) None);
+  test "any - [None;None]" (fun t ->
+    deepEqual t (any [None;None]) None);
+  test "any - [None;Some 1]" (fun t ->
+    deepEqual t (any [None;Some 1]) (Some 1));
+  test "any - [None;Some 1]" (fun t ->
+    deepEqual t (any [Some 1;Some 2]) (Some 1));
+
+  test "exists - Some x, f x = true" (fun t ->
+    deepEqual t (exists ((=) 3) (Some 3)) true);
+  test "filter - Some x, f x = false" (fun t ->
+    deepEqual t (exists (fun _ -> false) (Some 3)) false);
+  test "filter - None" (fun t ->
+    deepEqual t (exists (fun _ -> true) None) false);
+
+  test "forAll - Some x, f x = true" (fun t ->
+    deepEqual t (forAll ((=) 3) (Some 3)) true);
+  test "forAll - Some x, f x = false" (fun t ->
+    deepEqual t (forAll (fun _ -> false) (Some 3)) false);
+  test "forAll - None" (fun t ->
+    deepEqual t (forAll (fun _ -> true) None) true);
+
+  test "okOr - Some _" (fun t ->
+    deepEqual t (okOr 2 (Some "a")) (Ok "a"));
+  test "okOr - None" (fun t ->
+    deepEqual t (okOr 2 None) (Error 2));
+
+  test "okOrLazy - Some _" (fun t ->
+    deepEqual t (okOrLazy (fun () -> 2) (Some "a")) (Ok "a"));
+  test "okOrLazy - None" (fun t ->
+    deepEqual t (okOrLazy (fun () -> 2) None) (Error 2));
+
+  test "toList - Some _" (fun t ->
+    deepEqual t (toList (Some "a")) ["a"]);
+  test "toList - None" (fun t ->
+    deepEqual t (toList None) []);
+
+  test "toSeq - Some _" (fun t ->
+    let seq = toSeq (Some 4) in
+    plan t 1;
+    seq (function | 4 -> pass t | _ -> fail t));
+  test "toSeq - None" (fun t ->
+    let seq = toSeq None in
+    plan t 0;
+    seq (function | _ -> fail t));

--- a/test/__tests__/bopt_test.ml
+++ b/test/__tests__/bopt_test.ml
@@ -1,0 +1,6 @@
+open Test
+open Bopt
+
+let _ =
+  test "make" (fun t ->
+    deepEqual t (make 42) (Some 42))

--- a/test/test.ml
+++ b/test/test.ml
@@ -3,16 +3,14 @@ type t
 external ava:'a Js.t = "ava" [@@bs.module]
 
 let test = fun name run -> ava##test name run
-
 let test_ = fun run -> ava##test "" run
 
+external pass: t -> unit -> unit = "" [@@bs.send]
+external fail: t -> unit -> unit = "" [@@bs.send]
 external deepEqual: t -> 'a -> 'a -> unit = "deepEqual" [@@bs.send]
 
-external pass: t -> unit -> unit = "" [@@bs.send]
-
-external fail: t -> unit -> unit = "" [@@bs.send]
 
 let () = test "dummy" (fun t ->
-    deepEqual t 1 1;
-    pass t ()
+  deepEqual t 1 1;
+  pass t ()
 )

--- a/test/test.ml
+++ b/test/test.ml
@@ -5,12 +5,14 @@ external ava:'a Js.t = "ava" [@@bs.module]
 let test = fun name run -> ava##test name run
 let test_ = fun run -> ava##test "" run
 
-external pass: t -> unit -> unit = "" [@@bs.send]
-external fail: t -> unit -> unit = "" [@@bs.send]
+external pass: t -> unit = "" [@@bs.send]
+external fail: t -> unit = "" [@@bs.send]
 external deepEqual: t -> 'a -> 'a -> unit = "deepEqual" [@@bs.send]
+
+external plan: t -> int -> unit = "" [@@bs.send]
 
 
 let () = test "dummy" (fun t ->
   deepEqual t 1 1;
-  pass t ()
+  pass t
 )

--- a/test/test.mli
+++ b/test/test.mli
@@ -4,6 +4,8 @@ type t
 val test: string -> (t -> unit) -> unit
 val test_: (t -> unit) -> unit
 
-val pass: t -> unit -> unit
-val fail: t -> unit -> unit
-val deepEqual: t -> 'a -> 'a -> unit
+external pass: t -> unit = "" [@@bs.send]
+external fail: t -> unit = "" [@@bs.send]
+external deepEqual: t -> 'a -> 'a -> unit = "deepEqual" [@@bs.send]
+
+external plan: t -> int -> unit = "" [@@bs.send]

--- a/test/test.mli
+++ b/test/test.mli
@@ -2,11 +2,8 @@
 type t
 
 val test: string -> (t -> unit) -> unit
-
 val test_: (t -> unit) -> unit
 
-val deepEqual: t -> 'a -> 'a -> unit
-
 val pass: t -> unit -> unit
-
 val fail: t -> unit -> unit
+val deepEqual: t -> 'a -> 'a -> unit


### PR DESCRIPTION
Names I'm unsure about:
* `flatMap` vs `andThen`
* `and_` vs `then_`
* `flatten` vs `join`
* `zip` vs `both`
* `make` vs `return` (it's really just an alias for `Some _` and `make` seems too general for monads like `result` with multiple type vars)
* `get` as an alias for `getOr` without argument label
* `maybe` as alias for `mapOr` without argument label
* `getOrRaise` vs `getExn` or similar
* `okOr` vs `toResult`
* `reduce` vs `fold`. Some libraries seem to have both, where `fold` does not take an initial value but instead raises an exception on `None`. So reduce seems slightly more correct, and is of course much more familiar to js devs.