### PR TITLE
Replace stdlib phase 1

### DIFF
--- a/src/barray.ml
+++ b/src/barray.ml
@@ -3,6 +3,8 @@
 
 (** {1 Array utils} *)
 
+include Array
+
 type 'a sequence = ('a -> unit) -> unit
 type 'a klist = unit -> [`Nil | `Cons of 'a * 'a klist]
 type 'a gen = unit -> 'a option

--- a/src/barray.mli
+++ b/src/barray.mli
@@ -3,6 +3,197 @@
 
 (** {1 Array utils} *)
 
+
+(*-- Start stdlib array, from https://github.com/ocaml/ocaml/blob/4.02.3/stdlib/array.mli --*)
+
+external length : 'a array -> int = "%array_length"
+(** Return the length (number of elements) of the given array. *)
+
+external get : 'a array -> int -> 'a = "%array_safe_get"
+(** [Array.get a n] returns the element number [n] of array [a].
+   The first element has number 0.
+   The last element has number [Array.length a - 1].
+   You can also write [a.(n)] instead of [Array.get a n].
+   Raise [Invalid_argument "index out of bounds"]
+   if [n] is outside the range 0 to [(Array.length a - 1)]. *)
+
+external set : 'a array -> int -> 'a -> unit = "%array_safe_set"
+(** [Array.set a n x] modifies array [a] in place, replacing
+   element number [n] with [x].
+   You can also write [a.(n) <- x] instead of [Array.set a n x].
+   Raise [Invalid_argument "index out of bounds"]
+   if [n] is outside the range 0 to [Array.length a - 1]. *)
+
+external make : int -> 'a -> 'a array = "caml_make_vect"
+(** [Array.make n x] returns a fresh array of length [n],
+   initialized with [x].
+   All the elements of this new array are initially
+   physically equal to [x] (in the sense of the [==] predicate).
+   Consequently, if [x] is mutable, it is shared among all elements
+   of the array, and modifying [x] through one of the array entries
+   will modify all other entries at the same time.
+   Raise [Invalid_argument] if [n < 0] or [n > Sys.max_array_length].
+   If the value of [x] is a floating-point number, then the maximum
+   size is only [Sys.max_array_length / 2].*)
+
+external create : int -> 'a -> 'a array = "caml_make_vect"
+  [@@ocaml.deprecated "Use Array.make instead."]
+(** @deprecated [Array.create] is an alias for {!Array.make}. *)
+
+val init : int -> (int -> 'a) -> 'a array
+(** [Array.init n f] returns a fresh array of length [n],
+   with element number [i] initialized to the result of [f i].
+   In other terms, [Array.init n f] tabulates the results of [f]
+   applied to the integers [0] to [n-1].
+   Raise [Invalid_argument] if [n < 0] or [n > Sys.max_array_length].
+   If the return type of [f] is [float], then the maximum
+   size is only [Sys.max_array_length / 2].*)
+
+val make_matrix : int -> int -> 'a -> 'a array array
+(** [Array.make_matrix dimx dimy e] returns a two-dimensional array
+   (an array of arrays) with first dimension [dimx] and
+   second dimension [dimy]. All the elements of this new matrix
+   are initially physically equal to [e].
+   The element ([x,y]) of a matrix [m] is accessed
+   with the notation [m.(x).(y)].
+   Raise [Invalid_argument] if [dimx] or [dimy] is negative or
+   greater than [Sys.max_array_length].
+   If the value of [e] is a floating-point number, then the maximum
+   size is only [Sys.max_array_length / 2]. *)
+
+val create_matrix : int -> int -> 'a -> 'a array array
+  [@@ocaml.deprecated "Use Array.make_matrix instead."]
+(** @deprecated [Array.create_matrix] is an alias for {!Array.make_matrix}. *)
+
+val append : 'a array -> 'a array -> 'a array
+(** [Array.append v1 v2] returns a fresh array containing the
+   concatenation of the arrays [v1] and [v2]. *)
+
+val concat : 'a array list -> 'a array
+(** Same as [Array.append], but concatenates a list of arrays. *)
+
+val sub : 'a array -> int -> int -> 'a array
+(** [Array.sub a start len] returns a fresh array of length [len],
+   containing the elements number [start] to [start + len - 1]
+   of array [a].
+   Raise [Invalid_argument "Array.sub"] if [start] and [len] do not
+   designate a valid subarray of [a]; that is, if
+   [start < 0], or [len < 0], or [start + len > Array.length a]. *)
+
+val copy : 'a array -> 'a array
+(** [Array.copy a] returns a copy of [a], that is, a fresh array
+   containing the same elements as [a]. *)
+
+val fill : 'a array -> int -> int -> 'a -> unit
+(** [Array.fill a ofs len x] modifies the array [a] in place,
+   storing [x] in elements number [ofs] to [ofs + len - 1].
+   Raise [Invalid_argument "Array.fill"] if [ofs] and [len] do not
+   designate a valid subarray of [a]. *)
+
+val blit : 'a array -> int -> 'a array -> int -> int -> unit
+(** [Array.blit v1 o1 v2 o2 len] copies [len] elements
+   from array [v1], starting at element number [o1], to array [v2],
+   starting at element number [o2]. It works correctly even if
+   [v1] and [v2] are the same array, and the source and
+   destination chunks overlap.
+   Raise [Invalid_argument "Array.blit"] if [o1] and [len] do not
+   designate a valid subarray of [v1], or if [o2] and [len] do not
+   designate a valid subarray of [v2]. *)
+
+val to_list : 'a array -> 'a list
+(** [Array.to_list a] returns the list of all the elements of [a]. *)
+
+val of_list : 'a list -> 'a array
+(** [Array.of_list l] returns a fresh array containing the elements
+   of [l]. *)
+
+val iter : ('a -> unit) -> 'a array -> unit
+(** [Array.iter f a] applies function [f] in turn to all
+   the elements of [a].  It is equivalent to
+   [f a.(0); f a.(1); ...; f a.(Array.length a - 1); ()]. *)
+
+val map : ('a -> 'b) -> 'a array -> 'b array
+(** [Array.map f a] applies function [f] to all the elements of [a],
+   and builds an array with the results returned by [f]:
+   [[| f a.(0); f a.(1); ...; f a.(Array.length a - 1) |]]. *)
+
+val iteri : (int -> 'a -> unit) -> 'a array -> unit
+(** Same as {!Array.iter}, but the
+   function is applied to the index of the element as first argument,
+   and the element itself as second argument. *)
+
+val mapi : (int -> 'a -> 'b) -> 'a array -> 'b array
+(** Same as {!Array.map}, but the
+   function is applied to the index of the element as first argument,
+   and the element itself as second argument. *)
+
+val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b array -> 'a
+(** [Array.fold_left f x a] computes
+   [f (... (f (f x a.(0)) a.(1)) ...) a.(n-1)],
+   where [n] is the length of the array [a]. *)
+
+val fold_right : ('b -> 'a -> 'a) -> 'b array -> 'a -> 'a
+(** [Array.fold_right f a x] computes
+   [f a.(0) (f a.(1) ( ... (f a.(n-1) x) ...))],
+   where [n] is the length of the array [a]. *)
+
+external make_float: int -> float array = "caml_make_float_vect"
+(** [Array.make_float n] returns a fresh float array of length [n],
+    with uninitialized data.
+    @since 4.02 *)
+
+(** {6 Sorting} *)
+
+
+val sort : ('a -> 'a -> int) -> 'a array -> unit
+(** Sort an array in increasing order according to a comparison
+   function.  The comparison function must return 0 if its arguments
+   compare as equal, a positive integer if the first is greater,
+   and a negative integer if the first is smaller (see below for a
+   complete specification).  For example, {!Pervasives.compare} is
+   a suitable comparison function, provided there are no floating-point
+   NaN values in the data.  After calling [Array.sort], the
+   array is sorted in place in increasing order.
+   [Array.sort] is guaranteed to run in constant heap space
+   and (at most) logarithmic stack space.
+   The current implementation uses Heap Sort.  It runs in constant
+   stack space.
+   Specification of the comparison function:
+   Let [a] be the array and [cmp] the comparison function.  The following
+   must be true for all x, y, z in a :
+-   [cmp x y] > 0 if and only if [cmp y x] < 0
+-   if [cmp x y] >= 0 and [cmp y z] >= 0 then [cmp x z] >= 0
+   When [Array.sort] returns, [a] contains the same elements as before,
+   reordered in such a way that for all i and j valid indices of [a] :
+-   [cmp a.(i) a.(j)] >= 0 if and only if i >= j
+*)
+
+val stable_sort : ('a -> 'a -> int) -> 'a array -> unit
+(** Same as {!Array.sort}, but the sorting algorithm is stable (i.e.
+   elements that compare equal are kept in their original order) and
+   not guaranteed to run in constant heap space.
+   The current implementation uses Merge Sort. It uses [n/2]
+   words of heap space, where [n] is the length of the array.
+   It is usually faster than the current implementation of {!Array.sort}.
+*)
+
+val fast_sort : ('a -> 'a -> int) -> 'a array -> unit
+(** Same as {!Array.sort} or {!Array.stable_sort}, whichever is faster
+    on typical input.
+*)
+
+
+(**/**)
+(** {6 Undocumented functions} *)
+
+(* The following is for system use only. Do not call directly. *)
+
+external unsafe_get : 'a array -> int -> 'a = "%array_unsafe_get"
+external unsafe_set : 'a array -> int -> 'a -> unit = "%array_unsafe_set"
+
+(*-- End stdlib array --*)
+
+
 type 'a sequence = ('a -> unit) -> unit
 type 'a klist = unit -> [`Nil | `Cons of 'a * 'a klist]
 type 'a gen = unit -> 'a option

--- a/src/barraylabels.ml
+++ b/src/barraylabels.ml
@@ -3,6 +3,8 @@
 
 (** {1 Array utils} *)
 
+include ArrayLabels
+
 type 'a sequence = ('a -> unit) -> unit
 type 'a klist = unit -> [`Nil | `Cons of 'a * 'a klist]
 type 'a gen = unit -> 'a option

--- a/src/barraylabels.mli
+++ b/src/barraylabels.mli
@@ -3,6 +3,197 @@
 
 (** {1 Array utils} *)
 
+
+(*-- Start stdlib arrayLabels, from https://github.com/ocaml/ocaml/blob/4.02.3/stdlib/arrayLabels.mli --*)
+
+external length : 'a array -> int = "%array_length"
+(** Return the length (number of elements) of the given array. *)
+
+external get : 'a array -> int -> 'a = "%array_safe_get"
+(** [ArrayLabels.get a n] returns the element number [n] of array [a].
+   The first element has number 0.
+   The last element has number [ArrayLabels.length a - 1].
+   You can also write [a.(n)] instead of [ArrayLabels.get a n].
+   Raise [Invalid_argument "index out of bounds"]
+   if [n] is outside the range 0 to [(ArrayLabels.length a - 1)]. *)
+
+external set : 'a array -> int -> 'a -> unit = "%array_safe_set"
+(** [ArrayLabels.set a n x] modifies array [a] in place, replacing
+   element number [n] with [x].
+   You can also write [a.(n) <- x] instead of [ArrayLabels.set a n x].
+   Raise [Invalid_argument "index out of bounds"]
+   if [n] is outside the range 0 to [ArrayLabels.length a - 1]. *)
+
+external make : int -> 'a -> 'a array = "caml_make_vect"
+(** [ArrayLabels.make n x] returns a fresh array of length [n],
+   initialized with [x].
+   All the elements of this new array are initially
+   physically equal to [x] (in the sense of the [==] predicate).
+   Consequently, if [x] is mutable, it is shared among all elements
+   of the array, and modifying [x] through one of the array entries
+   will modify all other entries at the same time.
+   Raise [Invalid_argument] if [n < 0] or [n > Sys.max_array_length].
+   If the value of [x] is a floating-point number, then the maximum
+   size is only [Sys.max_array_length / 2].*)
+
+external create : int -> 'a -> 'a array = "caml_make_vect"
+  [@@ocaml.deprecated "Use ArrayLabels.make instead."]
+(** @deprecated [ArrayLabels.create] is an alias for {!ArrayLabels.make}. *)
+
+val init : int -> f:(int -> 'a) -> 'a array
+(** [ArrayLabels.init n f] returns a fresh array of length [n],
+   with element number [i] initialized to the result of [f i].
+   In other terms, [ArrayLabels.init n f] tabulates the results of [f]
+   applied to the integers [0] to [n-1].
+   Raise [Invalid_argument] if [n < 0] or [n > Sys.max_array_length].
+   If the return type of [f] is [float], then the maximum
+   size is only [Sys.max_array_length / 2].*)
+
+val make_matrix : dimx:int -> dimy:int -> 'a -> 'a array array
+(** [ArrayLabels.make_matrix dimx dimy e] returns a two-dimensional array
+   (an array of arrays) with first dimension [dimx] and
+   second dimension [dimy]. All the elements of this new matrix
+   are initially physically equal to [e].
+   The element ([x,y]) of a matrix [m] is accessed
+   with the notation [m.(x).(y)].
+   Raise [Invalid_argument] if [dimx] or [dimy] is negative or
+   greater than [Sys.max_array_length].
+   If the value of [e] is a floating-point number, then the maximum
+   size is only [Sys.max_array_length / 2]. *)
+
+val create_matrix : dimx:int -> dimy:int -> 'a -> 'a array array
+  [@@ocaml.deprecated "Use ArrayLabels.make_matrix instead."]
+(** @deprecated [ArrayLabels.create_matrix] is an alias for
+   {!ArrayLabels.make_matrix}. *)
+
+val append : 'a array -> 'a array -> 'a array
+(** [ArrayLabels.append v1 v2] returns a fresh array containing the
+   concatenation of the arrays [v1] and [v2]. *)
+
+val concat : 'a array list -> 'a array
+(** Same as [ArrayLabels.append], but concatenates a list of arrays. *)
+
+val sub : 'a array -> pos:int -> len:int -> 'a array
+(** [ArrayLabels.sub a start len] returns a fresh array of length [len],
+   containing the elements number [start] to [start + len - 1]
+   of array [a].
+   Raise [Invalid_argument "Array.sub"] if [start] and [len] do not
+   designate a valid subarray of [a]; that is, if
+   [start < 0], or [len < 0], or [start + len > ArrayLabels.length a]. *)
+
+val copy : 'a array -> 'a array
+(** [ArrayLabels.copy a] returns a copy of [a], that is, a fresh array
+   containing the same elements as [a]. *)
+
+val fill : 'a array -> pos:int -> len:int -> 'a -> unit
+(** [ArrayLabels.fill a ofs len x] modifies the array [a] in place,
+   storing [x] in elements number [ofs] to [ofs + len - 1].
+   Raise [Invalid_argument "Array.fill"] if [ofs] and [len] do not
+   designate a valid subarray of [a]. *)
+
+val blit :
+  src:'a array -> src_pos:int -> dst:'a array -> dst_pos:int -> len:int ->
+    unit
+(** [ArrayLabels.blit v1 o1 v2 o2 len] copies [len] elements
+   from array [v1], starting at element number [o1], to array [v2],
+   starting at element number [o2]. It works correctly even if
+   [v1] and [v2] are the same array, and the source and
+   destination chunks overlap.
+   Raise [Invalid_argument "Array.blit"] if [o1] and [len] do not
+   designate a valid subarray of [v1], or if [o2] and [len] do not
+   designate a valid subarray of [v2]. *)
+
+val to_list : 'a array -> 'a list
+(** [ArrayLabels.to_list a] returns the list of all the elements of [a]. *)
+
+val of_list : 'a list -> 'a array
+(** [ArrayLabels.of_list l] returns a fresh array containing the elements
+   of [l]. *)
+
+val iter : f:('a -> unit) -> 'a array -> unit
+(** [ArrayLabels.iter f a] applies function [f] in turn to all
+   the elements of [a].  It is equivalent to
+   [f a.(0); f a.(1); ...; f a.(ArrayLabels.length a - 1); ()]. *)
+
+val map : f:('a -> 'b) -> 'a array -> 'b array
+(** [ArrayLabels.map f a] applies function [f] to all the elements of [a],
+   and builds an array with the results returned by [f]:
+   [[| f a.(0); f a.(1); ...; f a.(ArrayLabels.length a - 1) |]]. *)
+
+val iteri : f:(int -> 'a -> unit) -> 'a array -> unit
+(** Same as {!ArrayLabels.iter}, but the
+   function is applied to the index of the element as first argument,
+   and the element itself as second argument. *)
+
+val mapi : f:(int -> 'a -> 'b) -> 'a array -> 'b array
+(** Same as {!ArrayLabels.map}, but the
+   function is applied to the index of the element as first argument,
+   and the element itself as second argument. *)
+
+val fold_left : f:('a -> 'b -> 'a) -> init:'a -> 'b array -> 'a
+(** [ArrayLabels.fold_left f x a] computes
+   [f (... (f (f x a.(0)) a.(1)) ...) a.(n-1)],
+   where [n] is the length of the array [a]. *)
+
+val fold_right : f:('b -> 'a -> 'a) -> 'b array -> init:'a -> 'a
+(** [ArrayLabels.fold_right f a x] computes
+   [f a.(0) (f a.(1) ( ... (f a.(n-1) x) ...))],
+   where [n] is the length of the array [a]. *)
+
+
+(** {6 Sorting} *)
+
+
+val sort : cmp:('a -> 'a -> int) -> 'a array -> unit
+(** Sort an array in increasing order according to a comparison
+   function.  The comparison function must return 0 if its arguments
+   compare as equal, a positive integer if the first is greater,
+   and a negative integer if the first is smaller (see below for a
+   complete specification).  For example, {!Pervasives.compare} is
+   a suitable comparison function, provided there are no floating-point
+   NaN values in the data.  After calling [ArrayLabels.sort], the
+   array is sorted in place in increasing order.
+   [ArrayLabels.sort] is guaranteed to run in constant heap space
+   and (at most) logarithmic stack space.
+   The current implementation uses Heap Sort.  It runs in constant
+   stack space.
+   Specification of the comparison function:
+   Let [a] be the array and [cmp] the comparison function.  The following
+   must be true for all x, y, z in a :
+-   [cmp x y] > 0 if and only if [cmp y x] < 0
+-   if [cmp x y] >= 0 and [cmp y z] >= 0 then [cmp x z] >= 0
+   When [ArrayLabels.sort] returns, [a] contains the same elements as before,
+   reordered in such a way that for all i and j valid indices of [a] :
+-   [cmp a.(i) a.(j)] >= 0 if and only if i >= j
+*)
+
+val stable_sort : cmp:('a -> 'a -> int) -> 'a array -> unit
+(** Same as {!ArrayLabels.sort}, but the sorting algorithm is stable (i.e.
+   elements that compare equal are kept in their original order) and
+   not guaranteed to run in constant heap space.
+   The current implementation uses Merge Sort. It uses [n/2]
+   words of heap space, where [n] is the length of the array.
+   It is usually faster than the current implementation of {!ArrayLabels.sort}.
+*)
+
+val fast_sort : cmp:('a -> 'a -> int) -> 'a array -> unit
+(** Same as {!ArrayLabels.sort} or {!ArrayLabels.stable_sort}, whichever is
+    faster on typical input.
+*)
+
+
+(**/**)
+
+(** {6 Undocumented functions} *)
+
+(* The following is for system use only. Do not call directly. *)
+
+external unsafe_get : 'a array -> int -> 'a = "%array_unsafe_get"
+external unsafe_set : 'a array -> int -> 'a -> unit = "%array_unsafe_set"
+
+(*-- End stdlib arrayLabels --*)
+
+
 type 'a sequence = ('a -> unit) -> unit
 type 'a klist = unit -> [`Nil | `Cons of 'a * 'a klist]
 type 'a gen = unit -> 'a option

--- a/src/bchar.ml
+++ b/src/bchar.ml
@@ -4,7 +4,7 @@
 
     @since 0.14 *)
 
-type t = char
+include Char
 
 let equal (a:char) b = a=b
 let compare = Char.compare

--- a/src/bchar.mli
+++ b/src/bchar.mli
@@ -1,10 +1,45 @@
 (* This file is free software, part of containers. See file "license" for more details. *)
 
-(** {1 Utils around char}
+(** {1 Utils around char} *)
 
-    @since 0.14 *)
+
+(*-- Start stdlib char, from https://github.com/ocaml/ocaml/blob/4.02.3/stdlib/char.mli --*)
+
+external code : char -> int = "%identity"
+(** Return the ASCII code of the argument. *)
+
+val chr : int -> char
+(** Return the character with the given ASCII code.
+   Raise [Invalid_argument "Char.chr"] if the argument is
+   outside the range 0--255. *)
+
+val escaped : char -> string
+(** Return a string representing the given character,
+   with special characters escaped following the lexical conventions
+   of OCaml. *)
+
+val lowercase : char -> char
+(** Convert the given character to its equivalent lowercase character. *)
+
+val uppercase : char -> char
+(** Convert the given character to its equivalent uppercase character. *)
 
 type t = char
+(** An alias for the type of characters. *)
+
+val compare: t -> t -> int
+(** The comparison function for characters, with the same specification as
+    {!Pervasives.compare}.  Along with the type [t], this function [compare]
+    allows the module [Char] to be passed as argument to the functors
+    {!Set.Make} and {!Map.Make}. *)
+
+(**/**)
+
+(* The following is for system use only. Do not call directly. *)
+external unsafe_chr : int -> char = "%identity"
+
+(*-- End stdlib char --*)
+
 
 val equal : t -> t -> bool
 val compare : t -> t -> int

--- a/src/bformat.ml
+++ b/src/bformat.ml
@@ -3,6 +3,8 @@
 
 (** {1 Helpers for Format} *)
 
+include Format
+
 type 'a sequence = ('a -> unit) -> unit
 
 type t = Format.formatter

--- a/src/bformat.mli
+++ b/src/bformat.mli
@@ -1,9 +1,674 @@
 
 (* This file is free software, part of containers. See file "license" for more details. *)
 
-(** {1 Helpers for Format}
+(** {1 Helpers for Format} *)
 
-    @since 0.8 *)
+
+(*-- Start stdlib format, from https://github.com/ocaml/ocaml/blob/4.02.3/stdlib/format.mli --*)
+
+(** {6 Boxes} *)
+
+val open_box : int -> unit
+(** [open_box d] opens a new pretty-printing box
+   with offset [d].
+   This box is the general purpose pretty-printing box.
+   Material in this box is displayed 'horizontal or vertical':
+   break hints inside the box may lead to a new line, if there
+   is no more room on the line to print the remainder of the box,
+   or if a new line may lead to a new indentation
+   (demonstrating the indentation of the box).
+   When a new line is printed in the box, [d] is added to the
+   current indentation. *)
+
+val close_box : unit -> unit
+(** Closes the most recently opened pretty-printing box. *)
+
+(** {6 Formatting functions} *)
+
+val print_string : string -> unit
+(** [print_string str] prints [str] in the current box. *)
+
+val print_as : int -> string -> unit
+(** [print_as len str] prints [str] in the
+   current box. The pretty-printer formats [str] as if
+   it were of length [len]. *)
+
+val print_int : int -> unit
+(** Prints an integer in the current box. *)
+
+val print_float : float -> unit
+(** Prints a floating point number in the current box. *)
+
+val print_char : char -> unit
+(** Prints a character in the current box. *)
+
+val print_bool : bool -> unit
+(** Prints a boolean in the current box. *)
+
+(** {6 Break hints} *)
+
+val print_space : unit -> unit
+(** [print_space ()] is used to separate items (typically to print
+   a space between two words).
+   It indicates that the line may be split at this
+   point. It either prints one space or splits the line.
+   It is equivalent to [print_break 1 0]. *)
+
+val print_cut : unit -> unit
+(** [print_cut ()] is used to mark a good break position.
+   It indicates that the line may be split at this
+   point. It either prints nothing or splits the line.
+   This allows line splitting at the current
+   point, without printing spaces or adding indentation.
+   It is equivalent to [print_break 0 0]. *)
+
+val print_break : int -> int -> unit
+(** Inserts a break hint in a pretty-printing box.
+   [print_break nspaces offset] indicates that the line may
+   be split (a newline character is printed) at this point,
+   if the contents of the current box does not fit on the
+   current line.
+   If the line is split at that point, [offset] is added to
+   the current indentation. If the line is not split,
+   [nspaces] spaces are printed. *)
+
+val print_flush : unit -> unit
+(** Flushes the pretty printer: all opened boxes are closed,
+   and all pending text is displayed. *)
+
+val print_newline : unit -> unit
+(** Equivalent to [print_flush] followed by a new line. *)
+
+val force_newline : unit -> unit
+(** Forces a newline in the current box. Not the normal way of
+   pretty-printing, you should prefer break hints. *)
+
+val print_if_newline : unit -> unit
+(** Executes the next formatting command if the preceding line
+   has just been split. Otherwise, ignore the next formatting
+   command. *)
+
+(** {6 Margin} *)
+
+val set_margin : int -> unit
+(** [set_margin d] sets the value of the right margin
+   to [d] (in characters): this value is used to detect line
+   overflows that leads to split lines.
+   Nothing happens if [d] is smaller than 2.
+   If [d] is too large, the right margin is set to the maximum
+   admissible value (which is greater than [10^9]). *)
+
+val get_margin : unit -> int
+(** Returns the position of the right margin. *)
+
+(** {6 Maximum indentation limit} *)
+
+val set_max_indent : int -> unit
+(** [set_max_indent d] sets the value of the maximum
+   indentation limit to [d] (in characters):
+   once this limit is reached, boxes are rejected to the left,
+   if they do not fit on the current line.
+   Nothing happens if [d] is smaller than 2.
+   If [d] is too large, the limit is set to the maximum
+   admissible value (which is greater than [10^9]). *)
+
+val get_max_indent : unit -> int
+(** Return the value of the maximum indentation limit (in characters). *)
+
+(** {6 Formatting depth: maximum number of boxes allowed before ellipsis} *)
+
+val set_max_boxes : int -> unit
+(** [set_max_boxes max] sets the maximum number of boxes simultaneously
+   opened.
+   Material inside boxes nested deeper is printed as an ellipsis (more
+   precisely as the text returned by [get_ellipsis_text ()]).
+   Nothing happens if [max] is smaller than 2. *)
+
+val get_max_boxes : unit -> int
+(** Returns the maximum number of boxes allowed before ellipsis. *)
+
+val over_max_boxes : unit -> bool
+(** Tests if the maximum number of boxes allowed have already been opened. *)
+
+(** {6 Advanced formatting} *)
+
+val open_hbox : unit -> unit
+(** [open_hbox ()] opens a new pretty-printing box.
+   This box is 'horizontal': the line is not split in this box
+   (new lines may still occur inside boxes nested deeper). *)
+
+val open_vbox : int -> unit
+(** [open_vbox d] opens a new pretty-printing box
+   with offset [d].
+   This box is 'vertical': every break hint inside this
+   box leads to a new line.
+   When a new line is printed in the box, [d] is added to the
+   current indentation. *)
+
+val open_hvbox : int -> unit
+(** [open_hvbox d] opens a new pretty-printing box
+   with offset [d].
+   This box is 'horizontal-vertical': it behaves as an
+   'horizontal' box if it fits on a single line,
+   otherwise it behaves as a 'vertical' box.
+   When a new line is printed in the box, [d] is added to the
+   current indentation. *)
+
+val open_hovbox : int -> unit
+(** [open_hovbox d] opens a new pretty-printing box
+   with offset [d].
+   This box is 'horizontal or vertical': break hints
+   inside this box may lead to a new line, if there is no more room
+   on the line to print the remainder of the box.
+   When a new line is printed in the box, [d] is added to the
+   current indentation. *)
+
+(** {6 Tabulations} *)
+
+val open_tbox : unit -> unit
+(** Opens a tabulation box. *)
+
+val close_tbox : unit -> unit
+(** Closes the most recently opened tabulation box. *)
+
+val print_tbreak : int -> int -> unit
+(** Break hint in a tabulation box.
+   [print_tbreak spaces offset] moves the insertion point to
+   the next tabulation ([spaces] being added to this position).
+   Nothing occurs if insertion point is already on a
+   tabulation mark.
+   If there is no next tabulation on the line, then a newline
+   is printed and the insertion point moves to the first
+   tabulation of the box.
+   If a new line is printed, [offset] is added to the current
+   indentation. *)
+
+val set_tab : unit -> unit
+(** Sets a tabulation mark at the current insertion point. *)
+
+val print_tab : unit -> unit
+(** [print_tab ()] is equivalent to [print_tbreak 0 0]. *)
+
+(** {6 Ellipsis} *)
+
+val set_ellipsis_text : string -> unit
+(** Set the text of the ellipsis printed when too many boxes
+   are opened (a single dot, [.], by default). *)
+
+val get_ellipsis_text : unit -> string
+(** Return the text of the ellipsis. *)
+
+(** {6:tags Semantics Tags} *)
+
+type tag = string
+
+(** {i Semantics tags} (or simply {e tags}) are used to decorate printed
+   entities for user's defined purposes, e.g. setting font and giving size
+   indications for a display device, or marking delimitation of semantics
+   entities (e.g. HTML or TeX elements or terminal escape sequences).
+   By default, those tags do not influence line breaking calculation:
+   the tag 'markers' are not considered as part of the printing
+   material that drives line breaking (in other words, the length of
+   those strings is considered as zero for line breaking).
+   Thus, tag handling is in some sense transparent to pretty-printing
+   and does not interfere with usual indentation. Hence, a single
+   pretty printing routine can output both simple 'verbatim'
+   material or richer decorated output depending on the treatment of
+   tags. By default, tags are not active, hence the output is not
+   decorated with tag information. Once [set_tags] is set to [true],
+   the pretty printer engine honours tags and decorates the output
+   accordingly.
+   When a tag has been opened (or closed), it is both and successively
+   'printed' and 'marked'. Printing a tag means calling a
+   formatter specific function with the name of the tag as argument:
+   that 'tag printing' function can then print any regular material
+   to the formatter (so that this material is enqueued as usual in the
+   formatter queue for further line-breaking computation). Marking a
+   tag means to output an arbitrary string (the 'tag marker'),
+   directly into the output device of the formatter. Hence, the
+   formatter specific 'tag marking' function must return the tag
+   marker string associated to its tag argument. Being flushed
+   directly into the output device of the formatter, tag marker
+   strings are not considered as part of the printing material that
+   drives line breaking (in other words, the length of the strings
+   corresponding to tag markers is considered as zero for line
+   breaking). In addition, advanced users may take advantage of
+   the specificity of tag markers to be precisely output when the
+   pretty printer has already decided where to break the lines, and
+   precisely when the queue is flushed into the output device.
+   In the spirit of HTML tags, the default tag marking functions
+   output tags enclosed in "<" and ">": hence, the opening marker of
+   tag [t] is ["<t>"] and the closing marker ["</t>"].
+   Default tag printing functions just do nothing.
+   Tag marking and tag printing functions are user definable and can
+   be set by calling [set_formatter_tag_functions]. *)
+
+val open_tag : tag -> unit
+(** [open_tag t] opens the tag named [t]; the [print_open_tag]
+   function of the formatter is called with [t] as argument;
+   the tag marker [mark_open_tag t] will be flushed into the output
+   device of the formatter. *)
+
+val close_tag : unit -> unit
+(** [close_tag ()] closes the most recently opened tag [t].
+   In addition, the [print_close_tag] function of the formatter is called
+   with [t] as argument. The marker [mark_close_tag t] will be flushed
+   into the output device of the formatter. *)
+
+val set_tags : bool -> unit
+(** [set_tags b] turns on or off the treatment of tags (default is off). *)
+
+val set_print_tags : bool -> unit
+(**[set_print_tags b] turns on or off the printing of tags. *)
+
+val set_mark_tags : bool -> unit
+(** [set_mark_tags b] turns on or off the output of tag markers. *)
+
+val get_print_tags : unit -> bool
+(** Return the current status of tags printing. *)
+
+val get_mark_tags : unit -> bool
+(** Return the current status of tags marking. *)
+
+(** {6 Redirecting the standard formatter output} *)
+
+val set_formatter_out_channel : Pervasives.out_channel -> unit
+(** Redirect the pretty-printer output to the given channel.
+    (All the output functions of the standard formatter are set to the
+     default output functions printing to the given channel.) *)
+
+val set_formatter_output_functions :
+  (string -> int -> int -> unit) -> (unit -> unit) -> unit
+(** [set_formatter_output_functions out flush] redirects the
+   pretty-printer output functions to the functions [out] and
+   [flush].
+   The [out] function performs all the pretty-printer string output.
+   It is called with a string [s], a start position [p], and a number of
+   characters [n]; it is supposed to output characters [p] to [p + n - 1] of
+   [s].
+   The [flush] function is called whenever the pretty-printer is flushed
+   (via conversion [%!], or pretty-printing indications [@?] or [@.], or
+   using low level functions [print_flush] or [print_newline]). *)
+
+val get_formatter_output_functions :
+  unit -> (string -> int -> int -> unit) * (unit -> unit)
+(** Return the current output functions of the pretty-printer. *)
+
+(** {6:meaning Changing the meaning of standard formatter pretty printing} *)
+
+(** The [Format] module is versatile enough to let you completely redefine
+ the meaning of pretty printing: you may provide your own functions to define
+ how to handle indentation, line breaking, and even printing of all the
+ characters that have to be printed! *)
+
+type formatter_out_functions = {
+  out_string : string -> int -> int -> unit;
+  out_flush : unit -> unit;
+  out_newline : unit -> unit;
+  out_spaces : int -> unit;
+}
+
+
+val set_formatter_out_functions : formatter_out_functions -> unit
+(** [set_formatter_out_functions f]
+   Redirect the pretty-printer output to the functions [f.out_string]
+   and [f.out_flush] as described in
+   [set_formatter_output_functions]. In addition, the pretty-printer function
+   that outputs a newline is set to the function [f.out_newline] and
+   the function that outputs indentation spaces is set to the function
+   [f.out_spaces].
+   This way, you can change the meaning of indentation (which can be
+   something else than just printing space characters) and the meaning of new
+   lines opening (which can be connected to any other action needed by the
+   application at hand). The two functions [f.out_spaces] and [f.out_newline]
+   are normally connected to [f.out_string] and [f.out_flush]: respective
+   default values for [f.out_space] and [f.out_newline] are
+   [f.out_string (String.make n ' ') 0 n] and [f.out_string "\n" 0 1]. *)
+
+val get_formatter_out_functions : unit -> formatter_out_functions
+(** Return the current output functions of the pretty-printer,
+   including line breaking and indentation functions. Useful to record the
+   current setting and restore it afterwards. *)
+
+(** {6:tagsmeaning Changing the meaning of printing semantics tags} *)
+
+type formatter_tag_functions = {
+  mark_open_tag : tag -> string;
+  mark_close_tag : tag -> string;
+  print_open_tag : tag -> unit;
+  print_close_tag : tag -> unit;
+}
+(** The tag handling functions specific to a formatter:
+   [mark] versions are the 'tag marking' functions that associate a string
+   marker to a tag in order for the pretty-printing engine to flush
+   those markers as 0 length tokens in the output device of the formatter.
+   [print] versions are the 'tag printing' functions that can perform
+   regular printing when a tag is closed or opened. *)
+
+val set_formatter_tag_functions : formatter_tag_functions -> unit
+(** [set_formatter_tag_functions tag_funs] changes the meaning of
+   opening and closing tags to use the functions in [tag_funs].
+   When opening a tag name [t], the string [t] is passed to the
+   opening tag marking function (the [mark_open_tag] field of the
+   record [tag_funs]), that must return the opening tag marker for
+   that name. When the next call to [close_tag ()] happens, the tag
+   name [t] is sent back to the closing tag marking function (the
+   [mark_close_tag] field of record [tag_funs]), that must return a
+   closing tag marker for that name.
+   The [print_] field of the record contains the functions that are
+   called at tag opening and tag closing time, to output regular
+   material in the pretty-printer queue. *)
+
+val get_formatter_tag_functions : unit -> formatter_tag_functions
+(** Return the current tag functions of the pretty-printer. *)
+
+(** {6 Multiple formatted output} *)
+
+type formatter
+(** Abstract data corresponding to a pretty-printer (also called a
+  formatter) and all its machinery.
+  Defining new pretty-printers permits unrelated output of material in
+  parallel on several output channels.
+  All the parameters of a pretty-printer are local to this pretty-printer:
+  margin, maximum indentation limit, maximum number of boxes
+  simultaneously opened, ellipsis, and so on, are specific to
+  each pretty-printer and may be fixed independently.
+  Given a [Pervasives.out_channel] output channel [oc], a new formatter
+  writing to that channel is simply obtained by calling
+  [formatter_of_out_channel oc].
+  Alternatively, the [make_formatter] function allocates a new
+  formatter with explicit output and flushing functions
+  (convenient to output material to strings for instance).
+*)
+
+val formatter_of_out_channel : out_channel -> formatter
+(** [formatter_of_out_channel oc] returns a new formatter that
+   writes to the corresponding channel [oc]. *)
+
+val std_formatter : formatter
+(** The standard formatter used by the formatting functions
+   above. It is defined as [formatter_of_out_channel stdout]. *)
+
+val err_formatter : formatter
+(** A formatter to use with formatting functions below for
+   output to standard error. It is defined as
+   [formatter_of_out_channel stderr]. *)
+
+val formatter_of_buffer : Buffer.t -> formatter
+(** [formatter_of_buffer b] returns a new formatter writing to
+   buffer [b]. As usual, the formatter has to be flushed at
+   the end of pretty printing, using [pp_print_flush] or
+   [pp_print_newline], to display all the pending material. *)
+
+val stdbuf : Buffer.t
+(** The string buffer in which [str_formatter] writes. *)
+
+val str_formatter : formatter
+(** A formatter to use with formatting functions below for
+   output to the [stdbuf] string buffer.
+   [str_formatter] is defined as [formatter_of_buffer stdbuf]. *)
+
+val flush_str_formatter : unit -> string
+(** Returns the material printed with [str_formatter], flushes
+   the formatter and resets the corresponding buffer. *)
+
+val make_formatter :
+  (string -> int -> int -> unit) -> (unit -> unit) -> formatter
+(** [make_formatter out flush] returns a new formatter that writes according
+  to the output function [out], and the flushing function [flush]. For
+  instance, a formatter to the [Pervasives.out_channel] [oc] is returned by
+  [make_formatter (Pervasives.output oc) (fun () -> Pervasives.flush oc)]. *)
+
+(** {6 Basic functions to use with formatters} *)
+
+val pp_open_hbox : formatter -> unit -> unit
+val pp_open_vbox : formatter -> int -> unit
+val pp_open_hvbox : formatter -> int -> unit
+val pp_open_hovbox : formatter -> int -> unit
+val pp_open_box : formatter -> int -> unit
+val pp_close_box : formatter -> unit -> unit
+val pp_open_tag : formatter -> string -> unit
+val pp_close_tag : formatter -> unit -> unit
+val pp_print_string : formatter -> string -> unit
+val pp_print_as : formatter -> int -> string -> unit
+val pp_print_int : formatter -> int -> unit
+val pp_print_float : formatter -> float -> unit
+val pp_print_char : formatter -> char -> unit
+val pp_print_bool : formatter -> bool -> unit
+val pp_print_break : formatter -> int -> int -> unit
+val pp_print_cut : formatter -> unit -> unit
+val pp_print_space : formatter -> unit -> unit
+val pp_force_newline : formatter -> unit -> unit
+val pp_print_flush : formatter -> unit -> unit
+val pp_print_newline : formatter -> unit -> unit
+val pp_print_if_newline : formatter -> unit -> unit
+val pp_open_tbox : formatter -> unit -> unit
+val pp_close_tbox : formatter -> unit -> unit
+val pp_print_tbreak : formatter -> int -> int -> unit
+val pp_set_tab : formatter -> unit -> unit
+val pp_print_tab : formatter -> unit -> unit
+val pp_set_tags : formatter -> bool -> unit
+val pp_set_print_tags : formatter -> bool -> unit
+val pp_set_mark_tags : formatter -> bool -> unit
+val pp_get_print_tags : formatter -> unit -> bool
+val pp_get_mark_tags : formatter -> unit -> bool
+val pp_set_margin : formatter -> int -> unit
+val pp_get_margin : formatter -> unit -> int
+val pp_set_max_indent : formatter -> int -> unit
+val pp_get_max_indent : formatter -> unit -> int
+val pp_set_max_boxes : formatter -> int -> unit
+val pp_get_max_boxes : formatter -> unit -> int
+val pp_over_max_boxes : formatter -> unit -> bool
+val pp_set_ellipsis_text : formatter -> string -> unit
+val pp_get_ellipsis_text : formatter -> unit -> string
+val pp_set_formatter_out_channel :
+  formatter -> Pervasives.out_channel -> unit
+
+val pp_set_formatter_output_functions :
+  formatter -> (string -> int -> int -> unit) -> (unit -> unit) -> unit
+
+val pp_get_formatter_output_functions :
+  formatter -> unit -> (string -> int -> int -> unit) * (unit -> unit)
+
+val pp_set_formatter_tag_functions :
+  formatter -> formatter_tag_functions -> unit
+
+val pp_get_formatter_tag_functions :
+  formatter -> unit -> formatter_tag_functions
+
+val pp_set_formatter_out_functions :
+  formatter -> formatter_out_functions -> unit
+
+val pp_get_formatter_out_functions :
+  formatter -> unit -> formatter_out_functions
+(** These functions are the basic ones: usual functions
+   operating on the standard formatter are defined via partial
+   evaluation of these primitives. For instance,
+   [print_string] is equal to [pp_print_string std_formatter]. *)
+
+(** {6 Convenience formatting functions.} *)
+
+val pp_print_list:
+  ?pp_sep:(formatter -> unit -> unit) ->
+  (formatter -> 'a -> unit) -> (formatter -> 'a list -> unit)
+(** [pp_print_list ?pp_sep pp_v ppf l] prints the list [l]. [pp_v] is
+    used on the elements of [l] and each element is separated by
+    a call to [pp_sep] (defaults to {!pp_print_cut}). Does nothing on
+    empty lists.
+    @since 4.02.0
+*)
+
+val pp_print_text : formatter -> string -> unit
+(** [pp_print_text ppf s] prints [s] with spaces and newlines
+    respectively printed with {!pp_print_space} and
+    {!pp_force_newline}.
+    @since 4.02.0
+*)
+
+(** {6 [printf] like functions for pretty-printing.} *)
+
+val fprintf : formatter -> ('a, formatter, unit) format -> 'a
+
+(** [fprintf ff fmt arg1 ... argN] formats the arguments [arg1] to [argN]
+   according to the format string [fmt], and outputs the resulting string on
+   the formatter [ff].
+   The format [fmt] is a character string which contains three types of
+   objects: plain characters and conversion specifications as specified in
+   the [Printf] module, and pretty-printing indications specific to the
+   [Format] module.
+   The pretty-printing indication characters are introduced by
+   a [@] character, and their meanings are:
+   - [@\[]: open a pretty-printing box. The type and offset of the
+     box may be optionally specified with the following syntax:
+     the [<] character, followed by an optional box type indication,
+     then an optional integer offset, and the closing [>] character.
+     Box type is one of [h], [v], [hv], [b], or [hov],
+     which stand respectively for an horizontal box, a vertical box,
+     an 'horizontal-vertical' box, or an 'horizontal or
+     vertical' box ([b] standing for an 'horizontal or
+     vertical' box demonstrating indentation and [hov] standing
+     for a regular'horizontal or vertical' box).
+     For instance, [@\[<hov 2>] opens an 'horizontal or vertical'
+     box with indentation 2 as obtained with [open_hovbox 2].
+     For more details about boxes, see the various box opening
+     functions [open_*box].
+   - [@\]]: close the most recently opened pretty-printing box.
+   - [@,]: output a good break hint, as with [print_cut ()].
+   - [@ ]: output a good break space, as with [print_space ()].
+   - [@;]: output a fully specified good break as with [print_break]. The
+     [nspaces] and [offset] parameters of the break may be
+     optionally specified with the following syntax:
+     the [<] character, followed by an integer [nspaces] value,
+     then an integer [offset], and a closing [>] character.
+     If no parameters are provided, the good break defaults to a
+     good break space.
+   - [@.]: flush the pretty printer and output a new line, as with
+     [print_newline ()].
+   - [@<n>]: print the following item as if it were of length [n].
+     Hence, [printf "@<0>%s" arg] prints [arg] as a zero length string.
+     If [@<n>] is not followed by a conversion specification,
+     then the following character of the format is printed as if
+     it were of length [n].
+   - [@\{]: open a tag. The name of the tag may be optionally
+     specified with the following syntax:
+     the [<] character, followed by an optional string
+     specification, and the closing [>] character. The string
+     specification is any character string that does not contain the
+     closing character ['>']. If omitted, the tag name defaults to the
+     empty string.
+     For more details about tags, see the functions [open_tag] and
+     [close_tag].
+   - [@\}]: close the most recently opened tag.
+   - [@?]: flush the pretty printer as with [print_flush ()].
+     This is equivalent to the conversion [%!].
+   - [@\n]: force a newline, as with [force_newline ()].
+   - [@@]: print a single [@] character.
+   Example: [printf "@[%s@ %d@]@." "x =" 1] is equivalent to
+   [open_box (); print_string "x ="; print_space ();
+    print_int 1; close_box (); print_newline ()].
+   It prints [x = 1] within a pretty-printing box.
+   Note: If you need to prevent the interpretation of a [@] character as a
+   pretty-printing indication, you can also escape it with a [%] character.
+*)
+
+val printf : ('a, formatter, unit) format -> 'a
+(** Same as [fprintf] above, but output on [std_formatter]. *)
+
+val eprintf : ('a, formatter, unit) format -> 'a
+(** Same as [fprintf] above, but output on [err_formatter]. *)
+
+val sprintf : ('a, unit, string) format -> 'a
+(** Same as [printf] above, but instead of printing on a formatter,
+   returns a string containing the result of formatting the arguments.
+   Note that the pretty-printer queue is flushed at the end of {e each
+   call} to [sprintf].
+   In case of multiple and related calls to [sprintf] to output
+   material on a single string, you should consider using [fprintf]
+   with the predefined formatter [str_formatter] and call
+   [flush_str_formatter ()] to get the final result.
+   Alternatively, you can use [Format.fprintf] with a formatter writing to a
+   buffer of your own: flushing the formatter and the buffer at the end of
+   pretty-printing returns the desired string.
+*)
+
+val asprintf : ('a, formatter, unit, string) format4 -> 'a
+(** Same as [printf] above, but instead of printing on a formatter,
+   returns a string containing the result of formatting the arguments.
+   The type of [asprintf] is general enough to interact nicely with [%a]
+   conversions.
+   @since 4.01.0
+ *)
+
+val ifprintf : formatter -> ('a, formatter, unit) format -> 'a
+(** Same as [fprintf] above, but does not print anything.
+   Useful to ignore some material when conditionally printing.
+   @since 3.10.0
+*)
+
+(** Formatted output functions with continuations. *)
+
+val kfprintf : (formatter -> 'a) -> formatter ->
+              ('b, formatter, unit, 'a) format4 -> 'b
+(** Same as [fprintf] above, but instead of returning immediately,
+   passes the formatter to its first argument at the end of printing. *)
+
+val ikfprintf : (formatter -> 'a) -> formatter ->
+              ('b, formatter, unit, 'a) format4 -> 'b
+(** Same as [kfprintf] above, but does not print anything.
+   Useful to ignore some material when conditionally printing.
+   @since 3.12.0
+*)
+
+val ksprintf : (string -> 'a) -> ('b, unit, string, 'a) format4 -> 'b
+(** Same as [sprintf] above, but instead of returning the string,
+   passes it to the first argument. *)
+
+(** {6 Deprecated} *)
+
+val bprintf : Buffer.t -> ('a, formatter, unit) format -> 'a
+  [@@ocaml.deprecated]
+(** @deprecated This function is error prone. Do not use it.
+  If you need to print to some buffer [b], you must first define a
+  formatter writing to [b], using [let to_b = formatter_of_buffer b]; then
+  use regular calls to [Format.fprintf] on formatter [to_b]. *)
+
+val kprintf : (string -> 'a) -> ('b, unit, string, 'a) format4 -> 'b
+  [@@ocaml.deprecated "Use Format.ksprintf instead."]
+(** @deprecated An alias for [ksprintf]. *)
+
+val set_all_formatter_output_functions :
+  out:(string -> int -> int -> unit) ->
+  flush:(unit -> unit) ->
+  newline:(unit -> unit) ->
+  spaces:(int -> unit) ->
+  unit
+[@@ocaml.deprecated "Use Format.set_formatter_out_functions instead."]
+(** @deprecated Subsumed by [set_formatter_out_functions]. *)
+
+val get_all_formatter_output_functions :
+  unit ->
+  (string -> int -> int -> unit) *
+  (unit -> unit) *
+  (unit -> unit) *
+  (int -> unit)
+[@@ocaml.deprecated "Use Format.get_formatter_out_functions instead."]
+(** @deprecated Subsumed by [get_formatter_out_functions]. *)
+
+val pp_set_all_formatter_output_functions :
+  formatter -> out:(string -> int -> int -> unit) -> flush:(unit -> unit) ->
+  newline:(unit -> unit) -> spaces:(int -> unit) -> unit
+[@@ocaml.deprecated "Use Format.pp_set_formatter_out_functions instead."]
+(** @deprecated Subsumed by [pp_set_formatter_out_functions]. *)
+
+val pp_get_all_formatter_output_functions :
+  formatter -> unit ->
+  (string -> int -> int -> unit) * (unit -> unit) * (unit -> unit) *
+  (int -> unit)
+[@@ocaml.deprecated "Use Format.pp_get_formatter_out_functions instead."]
+(** @deprecated Subsumed by [pp_get_formatter_out_functions]. *)
+
+(*-- End stdlib format --*)
+
 
 type 'a sequence = ('a -> unit) -> unit
 

--- a/src/blist.ml
+++ b/src/blist.ml
@@ -7,6 +7,8 @@
   let lsort l = List.sort Pervasives.compare l
 *)
 
+include List
+
 type 'a t = 'a list
 
 let empty = []

--- a/src/blist.mli
+++ b/src/blist.mli
@@ -3,6 +3,278 @@
 
 (** {1 complements to list} *)
 
+
+(*-- Start stdlib list, from https://github.com/ocaml/ocaml/blob/4.02.3/stdlib/list.mli --*)
+
+val length : 'a list -> int
+(** Return the length (number of elements) of the given list. *)
+
+val hd : 'a list -> 'a
+(** Return the first element of the given list. Raise
+   [Failure "hd"] if the list is empty. *)
+
+val tl : 'a list -> 'a list
+(** Return the given list without its first element. Raise
+   [Failure "tl"] if the list is empty. *)
+
+val nth : 'a list -> int -> 'a
+(** Return the [n]-th element of the given list.
+   The first element (head of the list) is at position 0.
+   Raise [Failure "nth"] if the list is too short.
+   Raise [Invalid_argument "List.nth"] if [n] is negative. *)
+
+val rev : 'a list -> 'a list
+(** List reversal. *)
+
+val append : 'a list -> 'a list -> 'a list
+(** Catenate two lists.  Same function as the infix operator [@].
+   Not tail-recursive (length of the first argument).  The [@]
+   operator is not tail-recursive either. *)
+
+val rev_append : 'a list -> 'a list -> 'a list
+(** [List.rev_append l1 l2] reverses [l1] and concatenates it to [l2].
+   This is equivalent to {!List.rev}[ l1 @ l2], but [rev_append] is
+   tail-recursive and more efficient. *)
+
+val concat : 'a list list -> 'a list
+(** Concatenate a list of lists.  The elements of the argument are all
+   concatenated together (in the same order) to give the result.
+   Not tail-recursive
+   (length of the argument + length of the longest sub-list). *)
+
+val flatten : 'a list list -> 'a list
+(** Same as [concat].  Not tail-recursive
+   (length of the argument + length of the longest sub-list). *)
+
+
+(** {6 Iterators} *)
+
+
+val iter : ('a -> unit) -> 'a list -> unit
+(** [List.iter f [a1; ...; an]] applies function [f] in turn to
+   [a1; ...; an]. It is equivalent to
+   [begin f a1; f a2; ...; f an; () end]. *)
+
+val iteri : (int -> 'a -> unit) -> 'a list -> unit
+(** Same as {!List.iter}, but the function is applied to the index of
+   the element as first argument (counting from 0), and the element
+   itself as second argument.
+   @since 4.00.0
+*)
+
+val map : ('a -> 'b) -> 'a list -> 'b list
+(** [List.map f [a1; ...; an]] applies function [f] to [a1, ..., an],
+   and builds the list [[f a1; ...; f an]]
+   with the results returned by [f].  Not tail-recursive. *)
+
+val mapi : (int -> 'a -> 'b) -> 'a list -> 'b list
+(** Same as {!List.map}, but the function is applied to the index of
+   the element as first argument (counting from 0), and the element
+   itself as second argument.  Not tail-recursive.
+   @since 4.00.0
+*)
+
+val rev_map : ('a -> 'b) -> 'a list -> 'b list
+(** [List.rev_map f l] gives the same result as
+   {!List.rev}[ (]{!List.map}[ f l)], but is tail-recursive and
+   more efficient. *)
+
+val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b list -> 'a
+(** [List.fold_left f a [b1; ...; bn]] is
+   [f (... (f (f a b1) b2) ...) bn]. *)
+
+val fold_right : ('a -> 'b -> 'b) -> 'a list -> 'b -> 'b
+(** [List.fold_right f [a1; ...; an] b] is
+   [f a1 (f a2 (... (f an b) ...))].  Not tail-recursive. *)
+
+
+(** {6 Iterators on two lists} *)
+
+
+val iter2 : ('a -> 'b -> unit) -> 'a list -> 'b list -> unit
+(** [List.iter2 f [a1; ...; an] [b1; ...; bn]] calls in turn
+   [f a1 b1; ...; f an bn].
+   Raise [Invalid_argument] if the two lists have
+   different lengths. *)
+
+val map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
+(** [List.map2 f [a1; ...; an] [b1; ...; bn]] is
+   [[f a1 b1; ...; f an bn]].
+   Raise [Invalid_argument] if the two lists have
+   different lengths.  Not tail-recursive. *)
+
+val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
+(** [List.rev_map2 f l1 l2] gives the same result as
+   {!List.rev}[ (]{!List.map2}[ f l1 l2)], but is tail-recursive and
+   more efficient. *)
+
+val fold_left2 : ('a -> 'b -> 'c -> 'a) -> 'a -> 'b list -> 'c list -> 'a
+(** [List.fold_left2 f a [b1; ...; bn] [c1; ...; cn]] is
+   [f (... (f (f a b1 c1) b2 c2) ...) bn cn].
+   Raise [Invalid_argument] if the two lists have
+   different lengths. *)
+
+val fold_right2 : ('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> 'c -> 'c
+(** [List.fold_right2 f [a1; ...; an] [b1; ...; bn] c] is
+   [f a1 b1 (f a2 b2 (... (f an bn c) ...))].
+   Raise [Invalid_argument] if the two lists have
+   different lengths.  Not tail-recursive. *)
+
+
+(** {6 List scanning} *)
+
+
+val for_all : ('a -> bool) -> 'a list -> bool
+(** [for_all p [a1; ...; an]] checks if all elements of the list
+   satisfy the predicate [p]. That is, it returns
+   [(p a1) && (p a2) && ... && (p an)]. *)
+
+val exists : ('a -> bool) -> 'a list -> bool
+(** [exists p [a1; ...; an]] checks if at least one element of
+   the list satisfies the predicate [p]. That is, it returns
+   [(p a1) || (p a2) || ... || (p an)]. *)
+
+val for_all2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
+(** Same as {!List.for_all}, but for a two-argument predicate.
+   Raise [Invalid_argument] if the two lists have
+   different lengths. *)
+
+val exists2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
+(** Same as {!List.exists}, but for a two-argument predicate.
+   Raise [Invalid_argument] if the two lists have
+   different lengths. *)
+
+val mem : 'a -> 'a list -> bool
+(** [mem a l] is true if and only if [a] is equal
+   to an element of [l]. *)
+
+val memq : 'a -> 'a list -> bool
+(** Same as {!List.mem}, but uses physical equality instead of structural
+   equality to compare list elements. *)
+
+
+(** {6 List searching} *)
+
+
+val find : ('a -> bool) -> 'a list -> 'a
+(** [find p l] returns the first element of the list [l]
+   that satisfies the predicate [p].
+   Raise [Not_found] if there is no value that satisfies [p] in the
+   list [l]. *)
+
+val filter : ('a -> bool) -> 'a list -> 'a list
+(** [filter p l] returns all the elements of the list [l]
+   that satisfy the predicate [p].  The order of the elements
+   in the input list is preserved.  *)
+
+val find_all : ('a -> bool) -> 'a list -> 'a list
+(** [find_all] is another name for {!List.filter}. *)
+
+val partition : ('a -> bool) -> 'a list -> 'a list * 'a list
+(** [partition p l] returns a pair of lists [(l1, l2)], where
+   [l1] is the list of all the elements of [l] that
+   satisfy the predicate [p], and [l2] is the list of all the
+   elements of [l] that do not satisfy [p].
+   The order of the elements in the input list is preserved. *)
+
+
+(** {6 Association lists} *)
+
+
+val assoc : 'a -> ('a * 'b) list -> 'b
+(** [assoc a l] returns the value associated with key [a] in the list of
+   pairs [l]. That is,
+   [assoc a [ ...; (a,b); ...] = b]
+   if [(a,b)] is the leftmost binding of [a] in list [l].
+   Raise [Not_found] if there is no value associated with [a] in the
+   list [l]. *)
+
+val assq : 'a -> ('a * 'b) list -> 'b
+(** Same as {!List.assoc}, but uses physical equality instead of structural
+   equality to compare keys. *)
+
+val mem_assoc : 'a -> ('a * 'b) list -> bool
+(** Same as {!List.assoc}, but simply return true if a binding exists,
+   and false if no bindings exist for the given key. *)
+
+val mem_assq : 'a -> ('a * 'b) list -> bool
+(** Same as {!List.mem_assoc}, but uses physical equality instead of
+   structural equality to compare keys. *)
+
+val remove_assoc : 'a -> ('a * 'b) list -> ('a * 'b) list
+(** [remove_assoc a l] returns the list of
+   pairs [l] without the first pair with key [a], if any.
+   Not tail-recursive. *)
+
+val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list
+(** Same as {!List.remove_assoc}, but uses physical equality instead
+   of structural equality to compare keys.  Not tail-recursive. *)
+
+
+(** {6 Lists of pairs} *)
+
+
+val split : ('a * 'b) list -> 'a list * 'b list
+(** Transform a list of pairs into a pair of lists:
+   [split [(a1,b1); ...; (an,bn)]] is [([a1; ...; an], [b1; ...; bn])].
+   Not tail-recursive.
+*)
+
+val combine : 'a list -> 'b list -> ('a * 'b) list
+(** Transform a pair of lists into a list of pairs:
+   [combine [a1; ...; an] [b1; ...; bn]] is
+   [[(a1,b1); ...; (an,bn)]].
+   Raise [Invalid_argument] if the two lists
+   have different lengths.  Not tail-recursive. *)
+
+
+(** {6 Sorting} *)
+
+
+val sort : ('a -> 'a -> int) -> 'a list -> 'a list
+(** Sort a list in increasing order according to a comparison
+   function.  The comparison function must return 0 if its arguments
+   compare as equal, a positive integer if the first is greater,
+   and a negative integer if the first is smaller (see Array.sort for
+   a complete specification).  For example,
+   {!Pervasives.compare} is a suitable comparison function.
+   The resulting list is sorted in increasing order.
+   [List.sort] is guaranteed to run in constant heap space
+   (in addition to the size of the result list) and logarithmic
+   stack space.
+   The current implementation uses Merge Sort. It runs in constant
+   heap space and logarithmic stack space.
+*)
+
+val stable_sort : ('a -> 'a -> int) -> 'a list -> 'a list
+(** Same as {!List.sort}, but the sorting algorithm is guaranteed to
+   be stable (i.e. elements that compare equal are kept in their
+   original order) .
+   The current implementation uses Merge Sort. It runs in constant
+   heap space and logarithmic stack space.
+*)
+
+val fast_sort : ('a -> 'a -> int) -> 'a list -> 'a list
+(** Same as {!List.sort} or {!List.stable_sort}, whichever is faster
+    on typical input. *)
+
+val sort_uniq : ('a -> 'a -> int) -> 'a list -> 'a list
+(** Same as {!List.sort}, but also remove duplicates.
+    @since 4.02.0 *)
+
+val merge : ('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
+(** Merge two lists:
+    Assuming that [l1] and [l2] are sorted according to the
+    comparison function [cmp], [merge cmp l1 l2] will return a
+    sorted list containting all the elements of [l1] and [l2].
+    If several elements compare equal, the elements of [l1] will be
+    before the elements of [l2].
+    Not tail-recursive (sum of the lengths of the arguments).
+*)
+
+(*-- End stdlib list -*)
+
+
 type 'a t = 'a list
 
 val empty : 'a t

--- a/src/blistlabels.ml
+++ b/src/blistlabels.ml
@@ -7,6 +7,8 @@
   let lsort l = List.sort Pervasives.compare l
 *)
 
+include ListLabels
+
 type 'a t = 'a list
 
 let empty = []

--- a/src/blistlabels.mli
+++ b/src/blistlabels.mli
@@ -3,6 +3,276 @@
 
 (** {1 complements to list} *)
 
+
+(*-- Start stdlib listlabels, from https://github.com/ocaml/ocaml/blob/4.02.3/stdlib/listLabels.mli --*)
+
+val length : 'a list -> int
+(** Return the length (number of elements) of the given list. *)
+
+val hd : 'a list -> 'a
+(** Return the first element of the given list. Raise
+   [Failure "hd"] if the list is empty. *)
+
+val tl : 'a list -> 'a list
+(** Return the given list without its first element. Raise
+   [Failure "tl"] if the list is empty. *)
+
+val nth : 'a list -> int -> 'a
+(** Return the [n]-th element of the given list.
+   The first element (head of the list) is at position 0.
+   Raise [Failure "nth"] if the list is too short.
+   Raise [Invalid_argument "List.nth"] if [n] is negative. *)
+
+val rev : 'a list -> 'a list
+(** List reversal. *)
+
+val append : 'a list -> 'a list -> 'a list
+(** Catenate two lists.  Same function as the infix operator [@].
+   Not tail-recursive (length of the first argument).  The [@]
+   operator is not tail-recursive either. *)
+
+val rev_append : 'a list -> 'a list -> 'a list
+(** [ListLabels.rev_append l1 l2] reverses [l1] and concatenates it to [l2].
+   This is equivalent to {!ListLabels.rev}[ l1 @ l2], but [rev_append] is
+   tail-recursive and more efficient. *)
+
+val concat : 'a list list -> 'a list
+(** Concatenate a list of lists.  The elements of the argument are all
+   concatenated together (in the same order) to give the result.
+   Not tail-recursive
+   (length of the argument + length of the longest sub-list). *)
+
+val flatten : 'a list list -> 'a list
+(** Same as [concat].  Not tail-recursive
+   (length of the argument + length of the longest sub-list). *)
+
+
+(** {6 Iterators} *)
+
+
+val iter : f:('a -> unit) -> 'a list -> unit
+(** [ListLabels.iter f [a1; ...; an]] applies function [f] in turn to
+   [a1; ...; an]. It is equivalent to
+   [begin f a1; f a2; ...; f an; () end]. *)
+
+val iteri : f:(int -> 'a -> unit) -> 'a list -> unit
+(** Same as {!ListLabels.iter}, but the function is applied to the index of
+   the element as first argument (counting from 0), and the element
+   itself as second argument.
+   @since 4.00.0
+*)
+
+val map : f:('a -> 'b) -> 'a list -> 'b list
+(** [ListLabels.map f [a1; ...; an]] applies function [f] to [a1, ..., an],
+   and builds the list [[f a1; ...; f an]]
+   with the results returned by [f].  Not tail-recursive. *)
+
+val mapi : f:(int -> 'a -> 'b) -> 'a list -> 'b list
+(** Same as {!ListLabels.map}, but the function is applied to the index of
+   the element as first argument (counting from 0), and the element
+   itself as second argument.
+   @since 4.00.0
+*)
+
+val rev_map : f:('a -> 'b) -> 'a list -> 'b list
+(** [ListLabels.rev_map f l] gives the same result as
+   {!ListLabels.rev}[ (]{!ListLabels.map}[ f l)], but is tail-recursive and
+   more efficient. *)
+
+val fold_left : f:('a -> 'b -> 'a) -> init:'a -> 'b list -> 'a
+(** [ListLabels.fold_left f a [b1; ...; bn]] is
+   [f (... (f (f a b1) b2) ...) bn]. *)
+
+val fold_right : f:('a -> 'b -> 'b) -> 'a list -> init:'b -> 'b
+(** [ListLabels.fold_right f [a1; ...; an] b] is
+   [f a1 (f a2 (... (f an b) ...))].  Not tail-recursive. *)
+
+
+(** {6 Iterators on two lists} *)
+
+
+val iter2 : f:('a -> 'b -> unit) -> 'a list -> 'b list -> unit
+(** [ListLabels.iter2 f [a1; ...; an] [b1; ...; bn]] calls in turn
+   [f a1 b1; ...; f an bn].
+   Raise [Invalid_argument] if the two lists have
+   different lengths. *)
+
+val map2 : f:('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
+(** [ListLabels.map2 f [a1; ...; an] [b1; ...; bn]] is
+   [[f a1 b1; ...; f an bn]].
+   Raise [Invalid_argument] if the two lists have
+   different lengths.  Not tail-recursive. *)
+
+val rev_map2 : f:('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
+(** [ListLabels.rev_map2 f l1 l2] gives the same result as
+   {!ListLabels.rev}[ (]{!ListLabels.map2}[ f l1 l2)], but is tail-recursive and
+   more efficient. *)
+
+val fold_left2 :
+  f:('a -> 'b -> 'c -> 'a) -> init:'a -> 'b list -> 'c list -> 'a
+(** [ListLabels.fold_left2 f a [b1; ...; bn] [c1; ...; cn]] is
+   [f (... (f (f a b1 c1) b2 c2) ...) bn cn].
+   Raise [Invalid_argument] if the two lists have
+   different lengths. *)
+
+val fold_right2 :
+  f:('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> init:'c -> 'c
+(** [ListLabels.fold_right2 f [a1; ...; an] [b1; ...; bn] c] is
+   [f a1 b1 (f a2 b2 (... (f an bn c) ...))].
+   Raise [Invalid_argument] if the two lists have
+   different lengths.  Not tail-recursive. *)
+
+
+(** {6 List scanning} *)
+
+
+val for_all : f:('a -> bool) -> 'a list -> bool
+(** [for_all p [a1; ...; an]] checks if all elements of the list
+   satisfy the predicate [p]. That is, it returns
+   [(p a1) && (p a2) && ... && (p an)]. *)
+
+val exists : f:('a -> bool) -> 'a list -> bool
+(** [exists p [a1; ...; an]] checks if at least one element of
+   the list satisfies the predicate [p]. That is, it returns
+   [(p a1) || (p a2) || ... || (p an)]. *)
+
+val for_all2 : f:('a -> 'b -> bool) -> 'a list -> 'b list -> bool
+(** Same as {!ListLabels.for_all}, but for a two-argument predicate.
+   Raise [Invalid_argument] if the two lists have
+   different lengths. *)
+
+val exists2 : f:('a -> 'b -> bool) -> 'a list -> 'b list -> bool
+(** Same as {!ListLabels.exists}, but for a two-argument predicate.
+   Raise [Invalid_argument] if the two lists have
+   different lengths. *)
+
+val mem : 'a -> set:'a list -> bool
+(** [mem a l] is true if and only if [a] is equal
+   to an element of [l]. *)
+
+val memq : 'a -> set:'a list -> bool
+(** Same as {!ListLabels.mem}, but uses physical equality instead of structural
+   equality to compare list elements. *)
+
+
+(** {6 List searching} *)
+
+
+val find : f:('a -> bool) -> 'a list -> 'a
+(** [find p l] returns the first element of the list [l]
+   that satisfies the predicate [p].
+   Raise [Not_found] if there is no value that satisfies [p] in the
+   list [l]. *)
+
+val filter : f:('a -> bool) -> 'a list -> 'a list
+(** [filter p l] returns all the elements of the list [l]
+   that satisfy the predicate [p].  The order of the elements
+   in the input list is preserved.  *)
+
+val find_all : f:('a -> bool) -> 'a list -> 'a list
+(** [find_all] is another name for {!ListLabels.filter}. *)
+
+val partition : f:('a -> bool) -> 'a list -> 'a list * 'a list
+(** [partition p l] returns a pair of lists [(l1, l2)], where
+   [l1] is the list of all the elements of [l] that
+   satisfy the predicate [p], and [l2] is the list of all the
+   elements of [l] that do not satisfy [p].
+   The order of the elements in the input list is preserved. *)
+
+
+(** {6 Association lists} *)
+
+
+val assoc : 'a -> ('a * 'b) list -> 'b
+(** [assoc a l] returns the value associated with key [a] in the list of
+   pairs [l]. That is,
+   [assoc a [ ...; (a,b); ...] = b]
+   if [(a,b)] is the leftmost binding of [a] in list [l].
+   Raise [Not_found] if there is no value associated with [a] in the
+   list [l]. *)
+
+val assq : 'a -> ('a * 'b) list -> 'b
+(** Same as {!ListLabels.assoc}, but uses physical equality instead of
+   structural equality to compare keys. *)
+
+val mem_assoc : 'a -> map:('a * 'b) list -> bool
+(** Same as {!ListLabels.assoc}, but simply return true if a binding exists,
+   and false if no bindings exist for the given key. *)
+
+val mem_assq : 'a -> map:('a * 'b) list -> bool
+(** Same as {!ListLabels.mem_assoc}, but uses physical equality instead of
+   structural equality to compare keys. *)
+
+val remove_assoc : 'a -> ('a * 'b) list -> ('a * 'b) list
+(** [remove_assoc a l] returns the list of
+   pairs [l] without the first pair with key [a], if any.
+   Not tail-recursive. *)
+
+val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list
+(** Same as {!ListLabels.remove_assoc}, but uses physical equality instead
+   of structural equality to compare keys.  Not tail-recursive. *)
+
+
+(** {6 Lists of pairs} *)
+
+
+val split : ('a * 'b) list -> 'a list * 'b list
+(** Transform a list of pairs into a pair of lists:
+   [split [(a1,b1); ...; (an,bn)]] is [([a1; ...; an], [b1; ...; bn])].
+   Not tail-recursive.
+*)
+
+val combine : 'a list -> 'b list -> ('a * 'b) list
+(** Transform a pair of lists into a list of pairs:
+   [combine [a1; ...; an] [b1; ...; bn]] is
+   [[(a1,b1); ...; (an,bn)]].
+   Raise [Invalid_argument] if the two lists
+   have different lengths.  Not tail-recursive. *)
+
+
+(** {6 Sorting} *)
+
+
+val sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
+(** Sort a list in increasing order according to a comparison
+   function.  The comparison function must return 0 if its arguments
+   compare as equal, a positive integer if the first is greater,
+   and a negative integer if the first is smaller (see Array.sort for
+   a complete specification).  For example,
+   {!Pervasives.compare} is a suitable comparison function.
+   The resulting list is sorted in increasing order.
+   [ListLabels.sort] is guaranteed to run in constant heap space
+   (in addition to the size of the result list) and logarithmic
+   stack space.
+   The current implementation uses Merge Sort. It runs in constant
+   heap space and logarithmic stack space.
+*)
+
+val stable_sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
+(** Same as {!ListLabels.sort}, but the sorting algorithm is guaranteed to
+   be stable (i.e. elements that compare equal are kept in their
+   original order) .
+   The current implementation uses Merge Sort. It runs in constant
+   heap space and logarithmic stack space.
+*)
+
+val fast_sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
+(** Same as {!ListLabels.sort} or {!ListLabels.stable_sort}, whichever is
+    faster on typical input. *)
+
+val merge : cmp:('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
+(** Merge two lists:
+    Assuming that [l1] and [l2] are sorted according to the
+    comparison function [cmp], [merge cmp l1 l2] will return a
+    sorted list containting all the elements of [l1] and [l2].
+    If several elements compare equal, the elements of [l1] will be
+    before the elements of [l2].
+    Not tail-recursive (sum of the lengths of the arguments).
+*)
+
+(*-- End stdlib listLabels --*)
+
+
 type 'a t = 'a list
 
 val empty : 'a t

--- a/src/bmap.ml
+++ b/src/bmap.ml
@@ -1,5 +1,7 @@
 (* This file is free software, part of containers. See file "license" for more details. *)
 
+module type OrderedType = Map.OrderedType
+
 module type S = sig
 
   type key

--- a/src/bmap.mli
+++ b/src/bmap.mli
@@ -4,6 +4,8 @@
     Provide a balanced tree as map container
 *)
 
+module type OrderedType = Map.OrderedType
+
 module type S = sig
 
   type key

--- a/src/brandom.ml
+++ b/src/brandom.ml
@@ -3,6 +3,8 @@
 
 (** {1 Random Generators} *)
 
+include Random
+
 type state = Random.State.t
 
 type 'a t = state -> 'a

--- a/src/brandom.mli
+++ b/src/brandom.mli
@@ -3,6 +3,103 @@
 
 (** {1 Random Generators} *)
 
+
+(*-- Start stdlib random, from https://github.com/ocaml/ocaml/blob/4.02.3/stdlib/random.mli --*)
+
+(** {6 Basic functions} *)
+
+val init : int -> unit
+(** Initialize the generator, using the argument as a seed.
+     The same seed will always yield the same sequence of numbers. *)
+
+val full_init : int array -> unit
+(** Same as {!Random.init} but takes more data as seed. *)
+
+val self_init : unit -> unit
+(** Initialize the generator with a random seed chosen
+   in a system-dependent way.  If [/dev/urandom] is available on
+   the host machine, it is used to provide a highly random initial
+   seed.  Otherwise, a less random seed is computed from system
+   parameters (current time, process IDs). *)
+
+val bits : unit -> int
+(** Return 30 random bits in a nonnegative integer.
+    @before 3.12.0 used a different algorithm (affects all the following
+                   functions)
+*)
+
+val int : int -> int
+(** [Random.int bound] returns a random integer between 0 (inclusive)
+     and [bound] (exclusive).  [bound] must be greater than 0 and less
+     than 2{^30}. *)
+
+val int32 : Int32.t -> Int32.t;;
+(** [Random.int32 bound] returns a random integer between 0 (inclusive)
+     and [bound] (exclusive).  [bound] must be greater than 0. *)
+
+val nativeint : Nativeint.t -> Nativeint.t;;
+(** [Random.nativeint bound] returns a random integer between 0 (inclusive)
+     and [bound] (exclusive).  [bound] must be greater than 0. *)
+
+val int64 : Int64.t -> Int64.t;;
+(** [Random.int64 bound] returns a random integer between 0 (inclusive)
+     and [bound] (exclusive).  [bound] must be greater than 0. *)
+
+val float : float -> float
+(** [Random.float bound] returns a random floating-point number
+   between 0 and [bound] (inclusive).  If [bound] is
+   negative, the result is negative or zero.  If [bound] is 0,
+   the result is 0. *)
+
+val bool : unit -> bool
+(** [Random.bool ()] returns [true] or [false] with probability 0.5 each. *)
+
+
+(** {6 Advanced functions} *)
+
+(** The functions from module [State] manipulate the current state
+    of the random generator explicitly.
+    This allows using one or several deterministic PRNGs,
+    even in a multi-threaded program, without interference from
+    other parts of the program.
+*)
+
+module State : sig
+  type t
+  (** The type of PRNG states. *)
+
+  val make : int array -> t
+  (** Create a new state and initialize it with the given seed. *)
+
+  val make_self_init : unit -> t
+  (** Create a new state and initialize it with a system-dependent
+      low-entropy seed. *)
+
+  val copy : t -> t
+  (** Return a copy of the given state. *)
+
+  val bits : t -> int
+  val int : t -> int -> int
+  val int32 : t -> Int32.t -> Int32.t
+  val nativeint : t -> Nativeint.t -> Nativeint.t
+  val int64 : t -> Int64.t -> Int64.t
+  val float : t -> float -> float
+  val bool : t -> bool
+  (** These functions are the same as the basic functions, except that they
+      use (and update) the given PRNG state instead of the default one.
+  *)
+end;;
+
+
+val get_state : unit -> State.t
+(** Return the current state of the generator used by the basic functions. *)
+
+val set_state : State.t -> unit
+(** Set the state of the generator used by the basic functions. *)
+
+(*-- End stdlib random --*)
+
+
 type state = Random.State.t
 
 type 'a t = state -> 'a

--- a/src/bset.ml
+++ b/src/bset.ml
@@ -3,6 +3,8 @@
 
 (** {1 Wrapper around Set} *)
 
+module type OrderedType = Set.OrderedType
+
 type 'a sequence = ('a -> unit) -> unit
 type 'a printer = Format.formatter -> 'a -> unit
 

--- a/src/bset.mli
+++ b/src/bset.mli
@@ -1,9 +1,9 @@
 
 (* This file is free software, part of containers. See file "license" for more details. *)
 
-(** {1 Wrapper around Set}
+(** {1 Wrapper around Set} *)
 
-    @since 0.9 *)
+module type OrderedType = Set.OrderedType
 
 type 'a sequence = ('a -> unit) -> unit
 type 'a printer = Format.formatter -> 'a -> unit

--- a/src/bstring.ml
+++ b/src/bstring.ml
@@ -3,6 +3,8 @@
 
 (** {1 Basic String Utils} *)
 
+include String
+
 type 'a gen = unit -> 'a option
 type 'a sequence = ('a -> unit) -> unit
 type 'a klist = unit -> [`Nil | `Cons of 'a * 'a klist]

--- a/src/bstring.mli
+++ b/src/bstring.mli
@@ -6,6 +6,199 @@
     Consider using {!Containers_string.KMP} for pattern search, or Regex
     libraries. *)
 
+
+(*-- Start stdlib string, from https://github.com/ocaml/ocaml/blob/4.02.3/stdlib/string.mli --*)
+
+external length : string -> int = "%string_length"
+(** Return the length (number of characters) of the given string. *)
+
+external get : string -> int -> char = "%string_safe_get"
+(** [String.get s n] returns the character at index [n] in string [s].
+   You can also write [s.[n]] instead of [String.get s n].
+   Raise [Invalid_argument] if [n] not a valid index in [s]. *)
+
+
+external set : bytes -> int -> char -> unit = "%string_safe_set"
+  [@@ocaml.deprecated "Use Bytes.set instead."]
+(** [String.set s n c] modifies byte sequence [s] in place,
+   replacing the byte at index [n] with [c].
+   You can also write [s.[n] <- c] instead of [String.set s n c].
+   Raise [Invalid_argument] if [n] is not a valid index in [s].
+   @deprecated This is a deprecated alias of {!Bytes.set}.[ ] *)
+
+external create : int -> bytes = "caml_create_string"
+  [@@ocaml.deprecated "Use Bytes.create instead."]
+(** [String.create n] returns a fresh byte sequence of length [n].
+   The sequence is uninitialized and contains arbitrary bytes.
+   Raise [Invalid_argument] if [n < 0] or [n > ]{!Sys.max_string_length}.
+   @deprecated This is a deprecated alias of {!Bytes.create}.[ ] *)
+
+val make : int -> char -> string
+(** [String.make n c] returns a fresh string of length [n],
+   filled with the character [c].
+   Raise [Invalid_argument] if [n < 0] or [n > ]{!Sys.max_string_length}. *)
+
+val init : int -> (int -> char) -> string
+(** [String.init n f] returns a string of length [n], with character
+    [i] initialized to the result of [f i] (called in increasing
+    index order).
+    Raise [Invalid_argument] if [n < 0] or [n > ]{!Sys.max_string_length}.
+    @since 4.02.0
+*)
+
+val copy : string -> string [@@ocaml.deprecated]
+(** Return a copy of the given string.
+    @deprecated Because strings are immutable, it doesn't make much
+    sense to make identical copies of them. *)
+
+val sub : string -> int -> int -> string
+(** [String.sub s start len] returns a fresh string of length [len],
+   containing the substring of [s] that starts at position [start] and
+   has length [len].
+   Raise [Invalid_argument] if [start] and [len] do not
+   designate a valid substring of [s]. *)
+
+val fill : bytes -> int -> int -> char -> unit
+  [@@ocaml.deprecated "Use Bytes.fill instead."]
+(** [String.fill s start len c] modifies byte sequence [s] in place,
+   replacing [len] bytes with [c], starting at [start].
+   Raise [Invalid_argument] if [start] and [len] do not
+   designate a valid range of [s].
+   @deprecated This is a deprecated alias of {!Bytes.fill}.[ ] *)
+
+val blit : string -> int -> bytes -> int -> int -> unit
+(** Same as {!Bytes.blit_string}. *)
+
+val concat : string -> string list -> string
+(** [String.concat sep sl] concatenates the list of strings [sl],
+    inserting the separator string [sep] between each.
+    Raise [Invalid_argument] if the result is longer than
+    {!Sys.max_string_length} bytes. *)
+
+val iter : (char -> unit) -> string -> unit
+(** [String.iter f s] applies function [f] in turn to all
+   the characters of [s].  It is equivalent to
+   [f s.[0]; f s.[1]; ...; f s.[String.length s - 1]; ()]. *)
+
+val iteri : (int -> char -> unit) -> string -> unit
+(** Same as {!String.iter}, but the
+   function is applied to the index of the element as first argument
+   (counting from 0), and the character itself as second argument.
+   @since 4.00.0 *)
+
+val map : (char -> char) -> string -> string
+(** [String.map f s] applies function [f] in turn to all the
+    characters of [s] (in increasing index order) and stores the
+    results in a new string that is returned.
+    @since 4.00.0 *)
+
+val mapi : (int -> char -> char) -> string -> string
+(** [String.mapi f s] calls [f] with each character of [s] and its
+    index (in increasing index order) and stores the results in a new
+    string that is returned.
+    @since 4.02.0 *)
+
+val trim : string -> string
+(** Return a copy of the argument, without leading and trailing
+   whitespace.  The characters regarded as whitespace are: [' '],
+   ['\012'], ['\n'], ['\r'], and ['\t'].  If there is neither leading nor
+   trailing whitespace character in the argument, return the original
+   string itself, not a copy.
+   @since 4.00.0 *)
+
+val escaped : string -> string
+(** Return a copy of the argument, with special characters
+   represented by escape sequences, following the lexical
+   conventions of OCaml.  If there is no special
+   character in the argument, return the original string itself,
+   not a copy. Its inverse function is Scanf.unescaped.
+   Raise [Invalid_argument] if the result is longer than
+   {!Sys.max_string_length} bytes. *)
+
+val index : string -> char -> int
+(** [String.index s c] returns the index of the first
+   occurrence of character [c] in string [s].
+   Raise [Not_found] if [c] does not occur in [s]. *)
+
+val rindex : string -> char -> int
+(** [String.rindex s c] returns the index of the last
+   occurrence of character [c] in string [s].
+   Raise [Not_found] if [c] does not occur in [s]. *)
+
+val index_from : string -> int -> char -> int
+(** [String.index_from s i c] returns the index of the
+   first occurrence of character [c] in string [s] after position [i].
+   [String.index s c] is equivalent to [String.index_from s 0 c].
+   Raise [Invalid_argument] if [i] is not a valid position in [s].
+   Raise [Not_found] if [c] does not occur in [s] after position [i]. *)
+
+val rindex_from : string -> int -> char -> int
+(** [String.rindex_from s i c] returns the index of the
+   last occurrence of character [c] in string [s] before position [i+1].
+   [String.rindex s c] is equivalent to
+   [String.rindex_from s (String.length s - 1) c].
+   Raise [Invalid_argument] if [i+1] is not a valid position in [s].
+   Raise [Not_found] if [c] does not occur in [s] before position [i+1]. *)
+
+val contains : string -> char -> bool
+(** [String.contains s c] tests if character [c]
+   appears in the string [s]. *)
+
+val contains_from : string -> int -> char -> bool
+(** [String.contains_from s start c] tests if character [c]
+   appears in [s] after position [start].
+   [String.contains s c] is equivalent to
+   [String.contains_from s 0 c].
+   Raise [Invalid_argument] if [start] is not a valid position in [s]. *)
+
+val rcontains_from : string -> int -> char -> bool
+(** [String.rcontains_from s stop c] tests if character [c]
+   appears in [s] before position [stop+1].
+   Raise [Invalid_argument] if [stop < 0] or [stop+1] is not a valid
+   position in [s]. *)
+
+val uppercase : string -> string
+(** Return a copy of the argument, with all lowercase letters
+   translated to uppercase, including accented letters of the ISO
+   Latin-1 (8859-1) character set. *)
+
+val lowercase : string -> string
+(** Return a copy of the argument, with all uppercase letters
+   translated to lowercase, including accented letters of the ISO
+   Latin-1 (8859-1) character set. *)
+
+val capitalize : string -> string
+(** Return a copy of the argument, with the first character set to uppercase. *)
+
+val uncapitalize : string -> string
+(** Return a copy of the argument, with the first character set to lowercase. *)
+
+type t = string
+(** An alias for the type of strings. *)
+
+val compare: t -> t -> int
+(** The comparison function for strings, with the same specification as
+    {!Pervasives.compare}.  Along with the type [t], this function [compare]
+    allows the module [String] to be passed as argument to the functors
+    {!Set.Make} and {!Map.Make}. *)
+
+(**/**)
+
+(* The following is for system use only. Do not call directly. *)
+
+external unsafe_get : string -> int -> char = "%string_unsafe_get"
+external unsafe_set : bytes -> int -> char -> unit = "%bytes_unsafe_set"
+  [@@ocaml.deprecated]
+external unsafe_blit :
+  string -> int -> bytes -> int -> int -> unit
+  = "caml_blit_string" "noalloc"
+external unsafe_fill :
+  bytes -> int -> int -> char -> unit = "caml_fill_string" "noalloc"
+  [@@ocaml.deprecated]
+
+(*-- End stdlib string --*)
+
+
 type 'a gen = unit -> 'a option
 type 'a sequence = ('a -> unit) -> unit
 type 'a klist = unit -> [`Nil | `Cons of 'a * 'a klist]

--- a/src/containers.ml
+++ b/src/containers.ml
@@ -1,85 +1,32 @@
 
 (* This file is free software, part of containers. See file "license" for more details. *)
 
-(** {1 Drop-In replacement to Stdlib}
+(** {1 Drop-In replacement to Stdlib} *)
 
-    This module is meant to be opened if one doesn't want to use both, say,
-    [List] and [BList]. Instead, [List] is now an alias to
-    {[struct
-      include List
-      include BList
-    end
-    ]}
-*)
-
-module Array = struct
-  include Array
-  include Barray
-end
-module ArrayLabels = struct
-  include ArrayLabels
-  include Barraylabels
-end
+module Array = Barray
+module ArrayLabels = ArrayLabels
 module Array_slice = Barray_slice
 module Bool = Bbool
-module Char = struct
-  include Char
-  include (Bchar : module type of Bchar with type t := t)
-end
+module Char = Bchar
 module Float = Bfloat
-module Format = struct
-  include Format
-  include Bformat
-end
+module Format = Bformat
 module Fun = Bfun
 module Hash = Bhash
+module Hashtbl = BHashtbl
+module Heap = Bheap
 module Int = Bint
 module Int64 = Bint64
-
-(** @since 0.14 *)
-module Hashtbl = struct
-  include (Hashtbl : module type of Hashtbl
-           with type statistics = Hashtbl.statistics
-            and module Make = Hashtbl.Make
-            and type ('a,'b) t = ('a,'b) Hashtbl.t
-          )
-  include Bhashtbl.Poly
-  module type S' = Bhashtbl.S
-  module Make' = Bhashtbl.Make
-end
-module Heap = Bheap
-module List = struct
-  include List
-  include Blist
-end
-module ListLabels = struct
-  include ListLabels
-  include Blistlabels
-end
-module Map = struct
-  module type OrderedType = Map.OrderedType
-  include Bmap
-end
+module List = Blist
+module ListLabels = Blistlabels
+module Map = Bmap
 module Option = Bopt
 module Ord = Bord
 module Pair = Bpair
 module Parse = Bparse
-module Random = struct
-  include Random
-  include Brandom
-end
+module Random = Brandom
 module Ref = Bref
-module Result = struct
-  include Result
-  include Bresult
-end
-module Set = struct
-  module type OrderedType = Set.OrderedType
-  include Bset
-end
-module String = struct
-  include String
-  include Bstring
-end
-module Vector = Bvector
+module Result = Bresult
+module Set = Bset
 module Sequence = Sequence
+module String = Bstring
+module Vector = Bvector


### PR DESCRIPTION
This incldues the std lib interface and implementation in each respective bs-containers module, removing them from and simplifying `containers.ml` to now just be simple aliases. Next step will be to rename and clean up the std lib interfaces, aliasing each function individually. Phase 3 will be to replace them with our own implementations.

PS: note that the hashtbl include was just removed instead of moved into bhashtbl, since it proved to be rather difficult to untangle all the module interdependencies cleanly. It will probably be easier to just rebuild it manually instead of going through the intermediary alias step.